### PR TITLE
add lsns command to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,4 +17,5 @@ RUN apk --no-cache add curl \
                        py-mysqldb \
                        py-psycopg2 \
                        py-yaml \
-                       python
+                       python \
+                       util-linux


### PR DESCRIPTION
Hi,

I get the following error, when try to use netdata in kubernetes, so I would like to add such binary to Dockerfile
```
/usr/libexec/netdata/plugins.d/cgroup-network-helper.sh: line 196: lsns: command not found
```

Thanks