### PR TITLE
netdata/packaging: Add nut as dependency for our base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,9 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
-# author  : paulfantom
+# This image is used to speed up build process for official netdata images.
+#
+# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author : paulfantom
+# Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
 
 # This image is used to speed up build process for official netdata images.
 
@@ -19,3 +23,6 @@ RUN apk --no-cache add curl \
                        py-yaml \
                        python \
                        util-linux
+
+# Add nut dependency from alpine-edge
+RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
As part of https://github.com/netdata/netdata/issues/5934 we are required to include nut package from alpine-edge for our runtime docker image.

APK command has been tested manually within a docker container.

Note: I also adjusted the notes at the top of the file

Fixes https://github.com/netdata/netdata/issues/5934