### PR TITLE
netdata/ci: Add another pre-compiled image to the list

### DIFF
--- a/oses/Dockerfile.opensuse42.3
+++ b/oses/Dockerfile.opensuse42.3
@@ -1,0 +1,25 @@
+FROM library/opensuse:42.3
+
+RUN zypper update -y
+
+RUN zypper install -y wget \
+                      curl \
+                      cups \
+                      freeipmi-devel \
+                      libmnl-devel \
+                      tar \
+                      sudo \
+                      libnetfilter_acct1 \
+                      gcc \
+                      make \
+                      automake \
+                      autoconf \
+                      lz4 \
+                      cups-devel \
+                      libuuid-devel \
+                      libJudy1 \
+                      libmnl0 \
+                      pkgconfig \
+                      git \
+                      libopenssl-devel \
+                      libnetfilter_acct-devel


### PR DESCRIPTION
This is a brand new docker image, so that we can have a ready to run openSuSe environment for our tests and troubleshooting