### PR TITLE
netdata/packaging: Add virsh command to base netdata image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,7 +30,8 @@ RUN apk --no-cache add curl \
                        libuv \
                        openssl \
                        lz4 \
-                       lz4-libs
+                       lz4-libs \
+                       libvirt-daemon
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/oses/Dockerfile.alpine
+++ b/oses/Dockerfile.alpine
@@ -22,4 +22,5 @@ RUN apk --no-cache add alpine-sdk \
                        libuv-dev \
                        lz4-dev \
                        openssl-dev \
-                       git
+                       git \
+                       libvirt-daemon

--- a/oses/Dockerfile.archlinux
+++ b/oses/Dockerfile.archlinux
@@ -14,4 +14,5 @@ RUN pacman --noconfirm --needed -S autoconf \
                                    netcat \
                                    openssl \
                                    pkgconfig \
-                                   python
+                                   python \
+                                   libvirt

--- a/oses/Dockerfile.centos6
+++ b/oses/Dockerfile.centos6
@@ -20,4 +20,5 @@ RUN yum install -y autoconf automake \
                         python-psycopg2 \
                         PyYAML \
                         zlib-devel \
-                        wget
+                        wget \
+                        libvirt-client

--- a/oses/Dockerfile.centos7
+++ b/oses/Dockerfile.centos7
@@ -20,4 +20,5 @@ RUN yum install -y autoconf automake \
                         python-psycopg2 \
                         PyYAML \
                         zlib-devel \
-                        wget
+                        wget \
+                        libvirt-client

--- a/oses/Dockerfile.debian_bookworm
+++ b/oses/Dockerfile.debian_bookworm
@@ -16,4 +16,5 @@ RUN apt-get install -y zlib1g-dev \
                        automake \
                        pkg-config \
                        curl \
-                       wget
+                       wget \
+                       libvirt-bin

--- a/oses/Dockerfile.debian_bullseye
+++ b/oses/Dockerfile.debian_bullseye
@@ -16,4 +16,5 @@ RUN apt-get install -y zlib1g-dev \
                        automake \
                        pkg-config \
                        curl \
-                       wget
+                       wget \
+                       libvirt-bin

--- a/oses/Dockerfile.debian_buster
+++ b/oses/Dockerfile.debian_buster
@@ -16,4 +16,5 @@ RUN apt-get install -y zlib1g-dev \
                        automake \
                        pkg-config \
                        curl \
-                       wget
+                       wget \
+                       libvirt-bin

--- a/oses/Dockerfile.debian_stretch
+++ b/oses/Dockerfile.debian_stretch
@@ -16,4 +16,5 @@ RUN apt-get install -y zlib1g-dev \
                        automake \
                        pkg-config \
                        curl \
-                       wget
+                       wget \
+                       libvirt-bin

--- a/oses/Dockerfile.debian_wheezy
+++ b/oses/Dockerfile.debian_wheezy
@@ -1,0 +1,19 @@
+FROM debian:wheezy
+
+RUN apt-get update
+RUN apt-get install -y zlib1g-dev \
+                       uuid-dev \
+                       liblz4-dev \
+                       libjudy-dev \
+                       libssl-dev \
+                       libmnl-dev \
+                       gcc \
+                       make \
+                       git \
+                       autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       pkg-config \
+                       curl \
+                       wget

--- a/oses/Dockerfile.fedora31
+++ b/oses/Dockerfile.fedora31
@@ -1,0 +1,25 @@
+FROM fedora:31
+
+RUN dnf update -y
+RUN dnf install -y autoconf automake \
+                        curl \
+                        gcc \
+                        git \
+                        libmnl-devel \
+                        libuuid-devel \
+                        openssl-devel \
+                        libuv-devel \
+                        lz4-devel \
+                        Judy-devel \
+                        lm_sensors \
+                        make \
+                        MySQL-python \
+                        nc \
+                        pkgconfig \
+                        python \
+                        python-psycopg2 \
+                        PyYAML \
+                        zlib-devel \
+                        wget \
+                        procps \
+                        findutils

--- a/oses/Dockerfile.opensuse15.0
+++ b/oses/Dockerfile.opensuse15.0
@@ -1,4 +1,4 @@
-FROM opensuse/leap:42.3
+FROM opensuse/leap:15.0
 
 RUN zypper update -y
 

--- a/oses/Dockerfile.opensuse15.1
+++ b/oses/Dockerfile.opensuse15.1
@@ -1,4 +1,4 @@
-FROM opensuse/leap:42.3
+FROM opensuse/leap:15.1
 
 RUN zypper update -y
 

--- a/oses/Dockerfile.opensuse_tumbleweed
+++ b/oses/Dockerfile.opensuse_tumbleweed
@@ -1,4 +1,4 @@
-FROM opensuse/leap:42.3
+FROM opensuse/tumbleweed:latest
 
 RUN zypper update -y
 

--- a/oses/Dockerfile.ubuntu1404
+++ b/oses/Dockerfile.ubuntu1404
@@ -1,0 +1,21 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get install -y zlib1g-dev \
+                       uuid-dev \
+                       libuv1-dev \
+                       liblz4-dev \
+                       libjudy-dev \
+                       libssl-dev \
+                       libmnl-dev \
+                       gcc \
+                       make \
+                       git \
+                       autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       pkg-config \
+                       curl \
+                       wget \
+                       && rm -rf /var/lib/apt/lists/*

--- a/oses/Dockerfile.ubuntu1904
+++ b/oses/Dockerfile.ubuntu1904
@@ -1,0 +1,22 @@
+FROM ubuntu:19.04
+
+RUN apt-get update && \
+    apt-get install -y zlib1g-dev \
+                       uuid-dev \
+                       libuv1-dev \
+                       liblz4-dev \
+                       libjudy-dev \
+                       libssl-dev \
+                       libmnl-dev \
+                       gcc \
+                       make \
+                       git \
+                       autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       pkg-config \
+                       curl \
+                       bats \
+                       wget \
+                       && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
virsh is a virtualisation command required by a plugin at runtime 
Fixes https://github.com/netdata/netdata/issues/6073