### PR TITLE
feat(freeipmi): Add support for freeipmi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ dist: trusty
 sudo: true
 language: c
 services:
-- docker
-jobs:
-  include:
-    - script: ./.travis/build.sh
-      if: branch = master
+  - docker
+env:
+  - ARCH=i386
+  - ARCH=armhf
+  - ARCH=aarch64
+  - ARCH=amd64
+branches:
+  only:
+  - master
+script: ./.travis/build.sh

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -16,10 +16,18 @@ fi
 
 echo "Initiating helper image building"
 
-if [ -z ${DEVEL+x} ]; then
+if [ ! -z ${ARCH+x} ]; then
+	# Specified architecture
+	declare -a ARCHITECTURES=(${ARCH})
+elif [ -z ${DEVEL+x} ]; then
+	# Default architectures
 	declare -a ARCHITECTURES=(i386 armhf aarch64 amd64)
 else
+	# Devel amd64 only
 	declare -a ARCHITECTURES=(amd64)
+fi
+
+if [ ! -z ${DEVEL+x} ]; then
 	unset DOCKER_PASSWORD
 	unset DOCKER_USERNAME
 fi

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -31,7 +31,8 @@ RUN apk --no-cache add curl \
                        openssl \
                        lz4 \
                        lz4-libs \
-                       libvirt-daemon
+                       libvirt-daemon \
+                       libgcrypt
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -6,8 +6,6 @@
 ARG ARCH=amd64-v3.9
 FROM multiarch/alpine:${ARCH} as builder
 
-ENV JUDY_VER 1.0.5
-
 # Install prerequisites
 RUN apk --no-cache add alpine-sdk \
                        autoconf \
@@ -30,15 +28,17 @@ RUN apk --no-cache add alpine-sdk \
                        zlib-dev \
                        libuv-dev \
                        lz4-dev \
-                       openssl-dev
+                       openssl-dev \
+                       libgcrypt-dev
 
 # Judy doesnt seem to be available on the repositories, download manually and install it
+ENV JUDY_VER 1.0.5
 RUN if [ "${ARCH}" == "aarch64" ]; then \
     echo "Executing ${ARCH} build, adding exceptional option --build for judy" \
     && wget -O /judy.tar.gz http://downloads.sourceforge.net/project/judy/judy/Judy-${JUDY_VER}/Judy-${JUDY_VER}.tar.gz \
     && cd / && tar -xf judy.tar.gz && rm judy.tar.gz \
     && cd /judy-${JUDY_VER} \
-    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure --build=aarch64-unknown-linux-gnu \
+    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure --build=aarch64-unknown-linux-gnu --prefix=/deps \
     && make \
     && make install; \
     # non aarch64 branch
@@ -46,7 +46,23 @@ RUN if [ "${ARCH}" == "aarch64" ]; then \
     wget -O /judy.tar.gz http://downloads.sourceforge.net/project/judy/judy/Judy-${JUDY_VER}/Judy-${JUDY_VER}.tar.gz \
     && cd / && tar -xf judy.tar.gz && rm judy.tar.gz \
     && cd /judy-${JUDY_VER} \
-    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure \
+    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure --prefix=/deps \
     && make \
     && make install; \
     fi;
+
+# freeipmi
+ENV FREEIPMI_VER 1.6.4
+COPY builder/patches/freeipmi-argp-redefine.patch /freeipmi-${FREEIPMI_VER}/
+RUN wget -O /freeipmi.tar.gz https://ftp.gnu.org/gnu/freeipmi/freeipmi-${FREEIPMI_VER}.tar.gz \
+    && cd / \
+    && tar -xf freeipmi.tar.gz \
+    && rm freeipmi.tar.gz \
+    && cd /freeipmi-${FREEIPMI_VER} \
+    && patch -p 0 < freeipmi-argp-redefine.patch \
+    && rm freeipmi-argp-redefine.patch \
+    && CPPFLAGS="-Dgetmsg\(a,b,c,d\)=errno=-1,-1 -Dputmsg\(a,b,c,d\)=errno=-1,-1" ./configure --prefix=/deps \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /freeipmi-${FREEIPMI_VER}

--- a/builder/patches/freeipmi-argp-redefine.patch
+++ b/builder/patches/freeipmi-argp-redefine.patch
@@ -1,0 +1,63 @@
+--- common/portability/freeipmi-argp-fmtstream.h.orig	2019-10-12 19:24:10.701766900 +0100
++++ common/portability/freeipmi-argp-fmtstream.h	2019-10-12 19:48:03.000226900 +0100
+@@ -145,6 +145,7 @@ extern ssize_t argp_fmtstream_printf (ar
+                                       __const char *__fmt, ...)
+      PRINTF_STYLE(2,3);
+ 
++#if __STDC_VERSION__ - 199900L < 1
+ extern int __argp_fmtstream_putc (argp_fmtstream_t __fs, int __ch);
+ extern int argp_fmtstream_putc (argp_fmtstream_t __fs, int __ch);
+ 
+@@ -155,6 +156,7 @@ extern size_t __argp_fmtstream_write (ar
+                                       __const char *__str, size_t __len);
+ extern size_t argp_fmtstream_write (argp_fmtstream_t __fs,
+                                     __const char *__str, size_t __len);
++#endif /* __STDC_VERSION__ - 199900L < 1 */
+ 
+ /* Access macros for various bits of state.  */
+ #define argp_fmtstream_lmargin(__fs) ((__fs)->lmargin)
+@@ -164,6 +166,7 @@ extern size_t argp_fmtstream_write (argp
+ #define __argp_fmtstream_rmargin argp_fmtstream_rmargin
+ #define __argp_fmtstream_wmargin argp_fmtstream_wmargin
+ 
++#if __STDC_VERSION__ - 199900L < 1
+ /* Set __FS's left margin to LMARGIN and return the old value.  */
+ extern size_t argp_fmtstream_set_lmargin (argp_fmtstream_t __fs,
+                                           size_t __lmargin);
+@@ -185,6 +188,7 @@ extern size_t __argp_fmtstream_set_wmarg
+ /* Return the column number of the current output point in __FS.  */
+ extern size_t argp_fmtstream_point (argp_fmtstream_t __fs);
+ extern size_t __argp_fmtstream_point (argp_fmtstream_t __fs);
++#endif /* __STDC_VERSION__ - 199900L < 1 */
+ 
+ /* Internal routines.  */
+ extern void _argp_fmtstream_update (argp_fmtstream_t __fs);
+@@ -208,7 +212,11 @@ extern int __argp_fmtstream_ensure (argp
+ #endif
+ 
+ #ifndef ARGP_FS_EI
++#if defined(__GNUC__) && !defined(__GNUC_STDC_INLINE__)
+ #define ARGP_FS_EI extern inline
++#else
++#define ARGP_FS_EI inline
++#endif
+ #endif
+ 
+ ARGP_FS_EI size_t
+--- common/portability/freeipmi-argp-fmtstream.c.orig	2019-10-12 19:22:44.463187100 +0100
++++ common/portability/freeipmi-argp-fmtstream.c	2019-10-12 19:23:57.335898900 +0100
+@@ -389,6 +389,7 @@ __argp_fmtstream_printf (struct argp_fmt
+ weak_alias (__argp_fmtstream_printf, argp_fmtstream_printf)
+ #endif
+ 
++#if __STDC_VERSION__ - 199900L < 1
+ /* Duplicate the inline definitions in argp-fmtstream.h, for compilers
+  * that don't do inlining. */
+ size_t
+@@ -471,5 +472,6 @@ __argp_fmtstream_point (argp_fmtstream_t
+     __argp_fmtstream_update (__fs);
+   return __fs->point_col >= 0 ? __fs->point_col : 0;
+ }
++#endif /* __STDC_VERSION__ - 199900L < 1 */
+ 
+ #endif /* !ARGP_FMTSTREAM_USE_LINEWRAP */


### PR DESCRIPTION
Add support for the freeipmi plugin when running in a docker container.

This includes a patch to freeipmi which fixes compilation on C99 compilers, as required for alpine.

Also:
* Move definition of JUDY_VER to above the judy layer so we don't have to rebuild the lower layers on version change.
* Install manually built dependencies into /deps which will allow for easy / quick install into to the netdata/netdata image.
* Use matrix build to speed up travis-ci and prevent timeouts.