### PR TITLE
Fix build of Opensuse Tumbleweed docker image

### DIFF
--- a/oses/Dockerfile.opensuse_tumbleweed
+++ b/oses/Dockerfile.opensuse_tumbleweed
@@ -2,6 +2,8 @@ FROM opensuse/tumbleweed:latest
 
 RUN zypper update -y
 
+RUN zypper install -y --oldpackage libcrypt1-4.4.3-2.3.x86_64
+
 RUN zypper install -y wget \
                       curl \
                       cups \


### PR DESCRIPTION
Satisfy cups-devel dependencies so that the [build](https://hub.docker.com/repository/registry-1.docker.io/netdata/os-test/builds/f04d8573-4b23-4e76-8855-150df46aaac8) does not fail