### PR TITLE
Add missing libuv1-devel dependency

### DIFF
--- a/builder/Dockerfile.gcc
+++ b/builder/Dockerfile.gcc
@@ -5,4 +5,5 @@ RUN apt-get update && apt-get install -y \
     autogen \
     libmnl-dev \
     uuid-dev \
+    libuv1-dev \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Apparently the package for `libuv` has changed from `libuv-devel` to `libuv1-devel`. But this also looked to be missing entirely from the `Dockerfile.gcc` file in the first place? (_not sure_). Either way the build script in `build/build.sh` fails with:

Also fixes #23 

```#!sh
prologic@Jamess-iMac
Thu Jan 02 10:47:39
~/NetData/netdata
 (master) 0
$ docker run --rm -it     --env IS_CONTAINER=TRUE     --volume "${PWD}:/project:Z"     --workdir "/project"     netdata/builder:gcc     ./build/build.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I build/m4
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
autoreconf: Leaving directory `.'
checking whether to enable maintainer-specific portions of Makefiles... yes
configure: ***************** MAINTAINER MODE *****************
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... no
checking for mawk... mawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking how to create a pax tar archive... gnutar
checking whether make supports nested variables... (cached) yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking whether make supports the include directive... yes (GNU style)
checking dependency style of gcc... gcc3
checking for gcc option to accept ISO C99... none needed
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking dependency style of g++... gcc3
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for __attribute__((returns_nonnull))... yes
checking for __attribute__((malloc))... yes
checking for __attribute__((noreturn))... yes
checking for __attribute__((noinline))... yes
checking for __attribute__((format))... yes
checking for __attribute__((warn_unused_result))... yes
checking for struct timespec... yes
checking for clockid_t... yes
checking for library containing clock_gettime... none required
checking for clock_gettime... yes
checking for sched_setscheduler... yes
checking for sched_getscheduler... yes
checking for sched_getparam... yes
checking for sched_get_priority_min... yes
checking for sched_get_priority_max... yes
checking for getpriority... yes
checking for setpriority... yes
checking for nice... yes
checking for recvmmsg... yes
checking for int8_t... yes
checking for int16_t... yes
checking for int32_t... yes
checking for int64_t... yes
checking for uint8_t... yes
checking for uint16_t... yes
checking for uint32_t... yes
checking for uint64_t... yes
checking for inline... inline
checking whether strerror_r is declared... yes
checking for strerror_r... yes
checking whether strerror_r returns char *... yes
checking for _Generic... yes
checking for __atomic... yes
checking size of void *... 8
checking whether sys/types.h defines makedev... no
checking sys/mkdev.h usability... no
checking sys/mkdev.h presence... no
checking for sys/mkdev.h... no
checking sys/sysmacros.h usability... yes
checking sys/sysmacros.h presence... yes
checking for sys/sysmacros.h... yes
checking for sys/types.h... (cached) yes
checking for netinet/in.h... yes
checking for arpa/nameser.h... yes
checking for netdb.h... yes
checking for resolv.h... yes
checking for sys/prctl.h... yes
checking for sys/vfs.h... yes
checking for sys/statfs.h... yes
checking for sys/statvfs.h... yes
checking for sys/mount.h... yes
checking for accept4... yes
checking operating system... linux with id 1
checking if compiler needs -Werror to reject unknown flags... no
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... no
checking whether pthreads work with -Kthread... no
checking whether pthreads work with -kthread... no
checking for the pthreads library -llthread... no
checking whether pthreads work with -pthread... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking for PTHREAD_PRIO_INHERIT... yes
checking for sin in -lm... yes
checking if libm should be used... yes
checking for uv_fs_scandir_next in -luv... no
configure: error: libuv required but not found. Try installing 'libuv1-dev' or 'libuv-devel'.
make: *** No rule to make target 'dist'.  Stop.
```

With this fix and the image built locally the build now works:

```#!sh
prologic@Jamess-iMac
Thu Jan 02 10:59:21
~/NetData/helper-images/builder
 (master) 0
$ docker build -f Dockerfile.gcc -t netdata/builder:gcc .
Sending build context to Docker daemon  4.608kB
Step 1/2 : FROM gcc:8
 ---> d8f76a90c7f1
Step 2/2 : RUN apt-get update && apt-get install -y     autoconf-archive     autogen     libmnl-dev     uuid-dev     libuv1-dev  && rm -rf /var/lib/apt/lists/*
 ---> Running in 3a0611da617e
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [49.3 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 Packages [7908 kB]
Get:5 http://security.debian.org/debian-security buster/updates/main amd64 Packages [167 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [5792 B]
Fetched 8317 kB in 3s (2883 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
uuid-dev is already the newest version (2.33.1-0.1).
uuid-dev set to manually installed.
The following additional packages will be installed:
  autogen-doc guile-2.0-libs libgc1c2 libopts25 libopts25-dev libuv1
The following NEW packages will be installed:
  autoconf-archive autogen autogen-doc guile-2.0-libs libgc1c2 libmnl-dev
  libopts25 libopts25-dev libuv1 libuv1-dev
0 upgraded, 10 newly installed, 0 to remove and 0 not upgraded.
Need to get 5220 kB of archives.
After this operation, 24.7 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main amd64 autoconf-archive all 20180313-1 [749 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 libgc1c2 amd64 1:7.6.4-0.4 [224 kB]
Get:3 http://deb.debian.org/debian buster/main amd64 guile-2.0-libs amd64 2.0.13+1-5.1 [2232 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 libopts25 amd64 1:5.18.12-4 [69.4 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 libopts25-dev amd64 1:5.18.12-4 [107 kB]
Get:6 http://deb.debian.org/debian buster/main amd64 autogen amd64 1:5.18.12-4 [568 kB]
Get:7 http://deb.debian.org/debian buster/main amd64 autogen-doc all 1:5.18.12-4 [1017 kB]
Get:8 http://deb.debian.org/debian buster/main amd64 libmnl-dev amd64 1.0.4-2 [13.3 kB]
Get:9 http://deb.debian.org/debian buster/main amd64 libuv1 amd64 1.24.1-1 [110 kB]
Get:10 http://deb.debian.org/debian buster/main amd64 libuv1-dev amd64 1.24.1-1 [130 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 5220 kB in 1s (5627 kB/s)
Selecting previously unselected package autoconf-archive.
(Reading database ... 23971 files and directories currently installed.)
Preparing to unpack .../0-autoconf-archive_20180313-1_all.deb ...
Unpacking autoconf-archive (20180313-1) ...
Selecting previously unselected package libgc1c2:amd64.
Preparing to unpack .../1-libgc1c2_1%3a7.6.4-0.4_amd64.deb ...
Unpacking libgc1c2:amd64 (1:7.6.4-0.4) ...
Selecting previously unselected package guile-2.0-libs:amd64.
Preparing to unpack .../2-guile-2.0-libs_2.0.13+1-5.1_amd64.deb ...
Unpacking guile-2.0-libs:amd64 (2.0.13+1-5.1) ...
Selecting previously unselected package libopts25:amd64.
Preparing to unpack .../3-libopts25_1%3a5.18.12-4_amd64.deb ...
Unpacking libopts25:amd64 (1:5.18.12-4) ...
Selecting previously unselected package libopts25-dev:amd64.
Preparing to unpack .../4-libopts25-dev_1%3a5.18.12-4_amd64.deb ...
Unpacking libopts25-dev:amd64 (1:5.18.12-4) ...
Selecting previously unselected package autogen.
Preparing to unpack .../5-autogen_1%3a5.18.12-4_amd64.deb ...
Unpacking autogen (1:5.18.12-4) ...
Replaced by files in installed package libopts25-dev:amd64 (1:5.18.12-4) ...
Selecting previously unselected package autogen-doc.
Preparing to unpack .../6-autogen-doc_1%3a5.18.12-4_all.deb ...
Unpacking autogen-doc (1:5.18.12-4) ...
Selecting previously unselected package libmnl-dev.
Preparing to unpack .../7-libmnl-dev_1.0.4-2_amd64.deb ...
Unpacking libmnl-dev (1.0.4-2) ...
Selecting previously unselected package libuv1:amd64.
Preparing to unpack .../8-libuv1_1.24.1-1_amd64.deb ...
Unpacking libuv1:amd64 (1.24.1-1) ...
Selecting previously unselected package libuv1-dev:amd64.
Preparing to unpack .../9-libuv1-dev_1.24.1-1_amd64.deb ...
Unpacking libuv1-dev:amd64 (1.24.1-1) ...
Setting up libgc1c2:amd64 (1:7.6.4-0.4) ...
Setting up autoconf-archive (20180313-1) ...
Setting up libopts25:amd64 (1:5.18.12-4) ...
Setting up autogen-doc (1:5.18.12-4) ...
Setting up libuv1:amd64 (1.24.1-1) ...
Setting up libmnl-dev (1.0.4-2) ...
Setting up libuv1-dev:amd64 (1.24.1-1) ...
Setting up libopts25-dev:amd64 (1:5.18.12-4) ...
Setting up guile-2.0-libs:amd64 (2.0.13+1-5.1) ...
Setting up autogen (1:5.18.12-4) ...
Processing triggers for libc-bin (2.28-10) ...
Removing intermediate container 3a0611da617e
 ---> 564060af5acd
Successfully built 564060af5acd
Successfully tagged netdata/builder:gcc
```