### PR TITLE
Fix failing Docker image builds.

### DIFF
--- a/oses/Dockerfile.alpine
+++ b/oses/Dockerfile.alpine
@@ -13,10 +13,10 @@ RUN apk --no-cache add alpine-sdk \
                        netcat-openbsd \
                        nodejs \
                        pkgconfig \
-                       py-mysqldb \
-                       py-psycopg2 \
-                       py-yaml \
-                       python \
+                       py3-mysql \
+                       py3-psycopg2 \
+                       py3-yaml \
+                       python3 \
                        util-linux-dev \
                        zlib-dev \
                        libuv-dev \

--- a/oses/Dockerfile.fedora31
+++ b/oses/Dockerfile.fedora31
@@ -13,10 +13,10 @@ RUN dnf install -y autoconf automake \
                         Judy-devel \
                         lm_sensors \
                         make \
-                        MySQL-python \
                         nc \
                         pkgconfig \
                         python \
+                        python-mysql \
                         python-psycopg2 \
                         PyYAML \
                         zlib-devel \


### PR DESCRIPTION
Currently, both Alpine and Fedora 31 Docker image builds are failing, ironically both due to changes in packaging of Python SQL modules.

For Alpine, this switches to using Python 3.X, as they appear to have removed a number of Python 2.X packages in preparation for 2.X going EOL this April. The switch necessitates also changing which MySQL package we're using for Python, as the `mysqldb` module is not packaged for Python 3.X on Alpine.

Similarly, Fedora 31 has dropped the MySQL-python package, apparently in favor of python-mysql (an equivalent change to the one mentioned above for Arch, just without the Python version switch).