### PR TITLE
Fix netdata/os-test:alpine image with correct py3-mysqlclient package

### DIFF
--- a/oses/Dockerfile.alpine
+++ b/oses/Dockerfile.alpine
@@ -13,7 +13,7 @@ RUN apk --no-cache add alpine-sdk \
                        netcat-openbsd \
                        nodejs \
                        pkgconfig \
-                       py3-mysql \
+                       py3-mysqlclient \
                        py3-psycopg2 \
                        py3-yaml \
                        python3 \


### PR DESCRIPTION
Fixes the image build error in https://hub.docker.com/repository/registry-1.docker.io/netdata/os-test/builds/40942ebc-80c4-43de-8007-9ae86ed08a9d

Verified by looking for the _right_ package:

```#!sh
prologic@Jamess-iMac
Sat Jan 04 15:11:19
~
 0
$ dki -t --rm alpine:latest /bin/sh
/ # apk update
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
v3.11.2-25-g58afcd742e [http://dl-cdn.alpinelinux.org/alpine/v3.11/main]
v3.11.2-24-g7cfe3a1534 [http://dl-cdn.alpinelinux.org/alpine/v3.11/community]
OK: 11261 distinct packages available
/ # apk search mysql | grep py
py3-mysqlclient-1.3.14-r3
/ #
```