### PR TITLE
Add shadow package required for usermod in run.sh

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,7 +32,8 @@ RUN apk --no-cache add curl \
                        lz4 \
                        lz4-libs \
                        libvirt-daemon \
-                       libgcrypt
+                       libgcrypt \
+                       shadow
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
This is required for `usermod` in https://github.com/netdata/netdata/blob/7bcb8c4148d7b303ef6e6cb145445f320af2b073/packaging/docker/run.sh#L24: `/usr/sbin/run.sh: line 24: usermod: command not found`.