### PR TITLE
Better isolate the sources from the build process.

### DIFF
--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -8,7 +8,11 @@ if [ -z "${BUILD_DATE}" ]; then
 	BUILD_DATE="$(date +%F)"
 fi
 
-cd /netdata || exit 1
+# Run the builds in an isolated source directory.
+# This removes the need for cleanup, and ensures anything the build does
+# doesn't muck with the user's sources.
+cp -a /netdata /usr/src || exit 1
+cd /usr/src/netdata || exit 1
 
 cp -a contrib/debian debian || exit 1
 
@@ -32,7 +36,9 @@ fi
 # Copy the built packages to /netdata/artifacts (which may be bind-mounted)
 # Also ensure /netdata/artifacts exists and create it if it doesn't
 [ -d /netdata/artifacts ] || mkdir -p /netdata/artifacts
-cp -a /*.deb /netdata/artifacts/ || exit 1
+cp -a /usr/src/*.deb /netdata/artifacts/ || exit 1
 
-# Cleanup
-rm -rf debian || exit 1
+# Correct ownership of the artifacts.
+# Without this, the artifacts directory and it's contents end up owned
+# by root instead of the local user on Linux boxes
+chown -R --reference=/netdata /netdata/artifacts


### PR DESCRIPTION
This changes how the source and artifacts directories are handled during builds for Debian packages in the following ways:

* The actual build is run in a copy of the sources that's local to the container. This ensures that the build leaves nothing it shouldn't in the user's source directory.
* The artifacts directory and it's contents are modified to have the same ownership as the original source directory.

Both of these are important on Linux systems because the scripts inside the container run as UID 0, which means that the files and directories produced in the source directory by the build are owned by root, and therefore it may not be possible for a regular user to remove them without explicitly elevating to EUID 0.

This is a non-issue on Mac and Windows systems because of how they handle Docker.