### PR TITLE
Revert "Use renamed/aliases opensuse images"

### DIFF
--- a/package-builders/Dockerfile.opensuse15.0
+++ b/package-builders/Dockerfile.opensuse15.0
@@ -1,6 +1,4 @@
-# NB: This is using a renamed/aliases image:
-#     $ docker tag opensuse/leap:15.0 opensuse:15.0
-FROM opensuse:15.0
+FROM opensuse/leap:15.0
 
 ARG VERSION=0.1
 

--- a/package-builders/Dockerfile.opensuse15.1
+++ b/package-builders/Dockerfile.opensuse15.1
@@ -1,6 +1,4 @@
-# NB: This is using a renamed/aliases image:
-#     $ docker tag opensuse/leap:15.1 opensuse:15.1
-FROM opensuse:15.1
+FROM opensuse/leap:15.1
 
 ARG VERSION=0.1
 


### PR DESCRIPTION
This reverts commit a59515740d6f4deb7b319c92011680b4dd752fc8.

As discussed we can do the image aliasing one step up where we need it in netdata/netdata#7735 when we integrate that work into a new packaging CI/CD flows.