### PR TITLE
Add 32-bit x86 package builder images for Debian and Ubuntu.

### DIFF
--- a/package-builders/Dockerfile.debian_bullseye_i386
+++ b/package-builders/Dockerfile.debian_bullseye_i386
@@ -1,0 +1,49 @@
+FROM i386/debian:bullseye
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to ensure package installs don't prompt for any user input.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.debian_buster_i386
+++ b/package-builders/Dockerfile.debian_buster_i386
@@ -1,0 +1,50 @@
+FROM i386/debian:buster
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to ensure package installs don't prompt for any user input.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.debian_jessie_i386
+++ b/package-builders/Dockerfile.debian_jessie_i386
@@ -1,0 +1,52 @@
+FROM i386/debian:jessie
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to ensure package installs don't prompt for any user input.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list
+RUN apt-get update -y -o Acquire::Check-Valid-Until=false
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       snappy \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.debian_stretch_i386
+++ b/package-builders/Dockerfile.debian_stretch_i386
@@ -1,0 +1,43 @@
+FROM i386/debian:stretch
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to ensure package installs don't prompt for any user input.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.ubuntu1604_i386
+++ b/package-builders/Dockerfile.ubuntu1604_i386
@@ -1,0 +1,50 @@
+FROM i386/ubuntu:16.04
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to keep package installs from prompting about configuration.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.ubuntu1804_i386
+++ b/package-builders/Dockerfile.ubuntu1804_i386
@@ -1,0 +1,50 @@
+FROM i386/ubuntu:18.04
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to keep package installs from prompting about configuration.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.ubuntu1904_i386
+++ b/package-builders/Dockerfile.ubuntu1904_i386
@@ -1,0 +1,50 @@
+FROM i386/ubuntu:19.04
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to keep package installs from prompting about configuration.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev

--- a/package-builders/Dockerfile.ubuntu1910_i386
+++ b/package-builders/Dockerfile.ubuntu1910_i386
@@ -1,0 +1,50 @@
+FROM i386/ubuntu:19.10
+
+ARG EMAIL=bot@netdata.cloud
+ARG FULLNAME="Netdata Builder"
+ARG VERSION=0.1
+
+ENV EMAIL=$EMAIL
+ENV FULLNAME=$FULLNAME
+ENV VERSION=$VERSION
+
+# This is needed to keep package installs from prompting about configuration.
+ARG DEBIAN_FRONTEND=noninteractive
+
+ADD package-builders/debian-build.sh /build.sh
+RUN chmod +x /build.sh
+
+RUN apt-get update
+RUN apt-get install -y autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev


### PR DESCRIPTION
These are needed so that we can build 32-bit x86 packages for these distributions to achieve parity between the current packaging using LXC and the new packaging workflow using Docker. This will eventually be obsoleted by the new `docker buildx` functionality once that's stable enough for us to use it.

Packages using the new images have been verified to build, install, and run correctly.

Tagging for these images is still TBD.