### PR TITLE
Add cmake to package builders.

### DIFF
--- a/package-builders/Dockerfile.centos7
+++ b/package-builders/Dockerfile.centos7
@@ -15,6 +15,7 @@ RUN yum install -y epel-release && \
                    autogen \
                    automake \
                    bash \
+                   cmake \
                    cups-devel \
                    curl \
                    diffutils \

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -16,6 +16,7 @@ RUN yum install -y 'dnf-command(config-manager)' && \
                    autogen \
                    automake \
                    bash \
+                   cmake \
                    cups-devel \
                    curl \
                    diffutils \

--- a/package-builders/Dockerfile.debian_bullseye
+++ b/package-builders/Dockerfile.debian_bullseye
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_bullseye_i386
+++ b/package-builders/Dockerfile.debian_bullseye_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_buster
+++ b/package-builders/Dockerfile.debian_buster
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_buster_i386
+++ b/package-builders/Dockerfile.debian_buster_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_jessie
+++ b/package-builders/Dockerfile.debian_jessie
@@ -21,6 +21,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        automake \
                        build-essential \
                        ca-certificates \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_jessie_i386
+++ b/package-builders/Dockerfile.debian_jessie_i386
@@ -21,6 +21,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        automake \
                        build-essential \
                        ca-certificates \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_stretch
+++ b/package-builders/Dockerfile.debian_stretch
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.debian_stretch_i386
+++ b/package-builders/Dockerfile.debian_stretch_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.fedora29
+++ b/package-builders/Dockerfile.fedora29
@@ -12,6 +12,7 @@ RUN dnf update -y && \
                    autogen \
                    automake \
                    bash \
+                   cmake \
                    cups-devel \
                    curl \
                    diffutils \

--- a/package-builders/Dockerfile.fedora30
+++ b/package-builders/Dockerfile.fedora30
@@ -12,6 +12,7 @@ RUN dnf update -y && \
                    autogen \
                    automake \
                    bash \
+                   cmake \
                    cups-devel \
                    curl \
                    diffutils \

--- a/package-builders/Dockerfile.fedora31
+++ b/package-builders/Dockerfile.fedora31
@@ -12,6 +12,7 @@ RUN dnf update -y && \
                    autogen \
                    automake \
                    bash \
+                   cmake \
                    cups-devel \
                    curl \
                    diffutils \

--- a/package-builders/Dockerfile.opensuse15.0
+++ b/package-builders/Dockerfile.opensuse15.0
@@ -11,6 +11,7 @@ RUN zypper update -y && \
                       autoconf-archive \
                       autogen \
                       automake \
+                      cmake \
                       cups \
                       cups-devel \
                       curl \

--- a/package-builders/Dockerfile.opensuse15.1
+++ b/package-builders/Dockerfile.opensuse15.1
@@ -11,6 +11,7 @@ RUN zypper update -y && \
                       autoconf-archive \
                       autogen \
                       automake \
+                      cmake \
                       cups \
                       cups-devel \
                       curl \

--- a/package-builders/Dockerfile.ubuntu1604
+++ b/package-builders/Dockerfile.ubuntu1604
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1604_i386
+++ b/package-builders/Dockerfile.ubuntu1604_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1804
+++ b/package-builders/Dockerfile.ubuntu1804
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1804_i386
+++ b/package-builders/Dockerfile.ubuntu1804_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1904
+++ b/package-builders/Dockerfile.ubuntu1904
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1904_i386
+++ b/package-builders/Dockerfile.ubuntu1904_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1910
+++ b/package-builders/Dockerfile.ubuntu1910
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \

--- a/package-builders/Dockerfile.ubuntu1910_i386
+++ b/package-builders/Dockerfile.ubuntu1910_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       cmake \
                        curl \
                        dh-autoreconf \
                        dh-make \


### PR DESCRIPTION
This is needed so that we can bundle libwebsockets properly.