### PR TITLE
Add missing dependencies to Debian and Ubuntu package builders.

### DIFF
--- a/package-builders/Dockerfile.debian_bullseye
+++ b/package-builders/Dockerfile.debian_bullseye
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.debian_bullseye_i386
+++ b/package-builders/Dockerfile.debian_bullseye_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.debian_buster
+++ b/package-builders/Dockerfile.debian_buster
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.debian_buster_i386
+++ b/package-builders/Dockerfile.debian_buster_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.debian_stretch
+++ b/package-builders/Dockerfile.debian_stretch
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \
@@ -30,14 +31,20 @@ RUN apt-get update && \
                        git-buildpackage \
                        libcups2-dev \
                        libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
                        libjudy-dev \
                        liblz4-dev \
                        libmnl-dev \
                        libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
                        libssl-dev \
                        libuv1-dev \
                        make \
                        pkg-config \
+                       protobuf-compiler \
                        uuid-dev \
                        wget \
                        zlib1g-dev && \

--- a/package-builders/Dockerfile.debian_stretch_i386
+++ b/package-builders/Dockerfile.debian_stretch_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \
@@ -30,14 +31,20 @@ RUN apt-get update && \
                        git-buildpackage \
                        libcups2-dev \
                        libdistro-info-perl \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
                        libjudy-dev \
                        liblz4-dev \
                        libmnl-dev \
                        libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
                        libssl-dev \
                        libuv1-dev \
                        make \
                        pkg-config \
+                       protobuf-compiler \
                        uuid-dev \
                        wget \
                        zlib1g-dev && \

--- a/package-builders/Dockerfile.ubuntu1604
+++ b/package-builders/Dockerfile.ubuntu1604
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1604_i386
+++ b/package-builders/Dockerfile.ubuntu1604_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1804
+++ b/package-builders/Dockerfile.ubuntu1804
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1804_i386
+++ b/package-builders/Dockerfile.ubuntu1804_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1904
+++ b/package-builders/Dockerfile.ubuntu1904
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1904_i386
+++ b/package-builders/Dockerfile.ubuntu1904_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1910
+++ b/package-builders/Dockerfile.ubuntu1910
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \

--- a/package-builders/Dockerfile.ubuntu1910_i386
+++ b/package-builders/Dockerfile.ubuntu1910_i386
@@ -19,6 +19,7 @@ RUN apt-get update && \
                        autogen \
                        automake \
                        build-essential \
+                       ca-certificates \
                        cmake \
                        curl \
                        dh-autoreconf \


### PR DESCRIPTION
As in the title.

Debian 9 is the big offender here, as it somehow is missing a bunch of required build dependencies.

This is a blocker for netdata/netdata#8065