### PR TITLE
Amend package-builder images for Debian/Ubuntu

### DIFF
--- a/package-builders/Dockerfile.debian10
+++ b/package-builders/Dockerfile.debian10
@@ -1,17 +1,11 @@
 FROM debian:buster
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian10_i386
+++ b/package-builders/Dockerfile.debian10_i386
@@ -1,17 +1,11 @@
 FROM i386/debian:buster
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian11
+++ b/package-builders/Dockerfile.debian11
@@ -1,17 +1,11 @@
 FROM debian:bullseye
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
 ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian11_i386
+++ b/package-builders/Dockerfile.debian11_i386
@@ -1,17 +1,11 @@
 FROM i386/debian:bullseye
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
 ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian8
+++ b/package-builders/Dockerfile.debian8
@@ -1,17 +1,11 @@
 FROM debian:jessie
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
 ARG VERSION=0.1
 
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
-
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && \
     apt-get update -y -o Acquire::Check-Valid-Until=false && \
@@ -26,6 +20,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -53,3 +48,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian8_i386
+++ b/package-builders/Dockerfile.debian8_i386
@@ -1,17 +1,11 @@
 FROM i386/debian:jessie
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non-free >> /etc/apt/sources.list.d/99-archived.list && \
     apt-get update -y -o Acquire::Check-Valid-Until=false && \
@@ -26,6 +20,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -53,3 +48,7 @@ RUN echo deb http://archive.debian.org/debian/ jessie-backports main contrib non
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian9
+++ b/package-builders/Dockerfile.debian9
@@ -1,17 +1,11 @@
 FROM debian:stretch
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-ADD package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        gcc \
                        git-core \
@@ -50,3 +45,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian9_i386
+++ b/package-builders/Dockerfile.debian9_i386
@@ -1,17 +1,11 @@
 FROM i386/debian:stretch
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to ensure package installs don't prompt for any user input.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        gcc \
                        git-core \
@@ -50,3 +45,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1604
+++ b/package-builders/Dockerfile.ubuntu1604
@@ -1,17 +1,11 @@
 FROM ubuntu:16.04
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1604_i386
+++ b/package-builders/Dockerfile.ubuntu1604_i386
@@ -1,17 +1,11 @@
 FROM i386/ubuntu:16.04
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1804
+++ b/package-builders/Dockerfile.ubuntu1804
@@ -1,17 +1,11 @@
 FROM ubuntu:18.04
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1804_i386
+++ b/package-builders/Dockerfile.ubuntu1804_i386
@@ -1,17 +1,11 @@
 FROM i386/ubuntu:18.04
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1910
+++ b/package-builders/Dockerfile.ubuntu1910
@@ -1,17 +1,11 @@
 FROM ubuntu:19.10
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu1910_i386
+++ b/package-builders/Dockerfile.ubuntu1910_i386
@@ -1,17 +1,11 @@
 FROM i386/ubuntu:19.10
 
-ARG EMAIL=bot@netdata.cloud
-ARG FULLNAME="Netdata Builder"
-ARG VERSION=0.1
-
-ENV EMAIL=$EMAIL
-ENV FULLNAME=$FULLNAME
-ENV VERSION=$VERSION
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
 
 # This is needed to keep package installs from prompting about configuration.
-ARG DEBIAN_FRONTEND=noninteractive
-
-COPY package-builders/debian-build.sh /build.sh
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends autoconf \
@@ -25,6 +19,7 @@ RUN apt-get update && \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \
+                       systemd \
                        dpkg-dev \
                        g++ \
                        gcc \
@@ -51,3 +46,7 @@ RUN apt-get update && \
                        zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/debian-build.sh /build.sh
+
+CMD ["/build.sh"]

--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -5,7 +5,7 @@
 CODENAME="$(awk -F"[)(]+" '/VERSION=/ {print $2}' /etc/os-release | cut -f 1 -d ' ' | tr '[:upper:]' '[:lower:]')"
 
 if [ -z "${BUILD_DATE}" ]; then
-	BUILD_DATE="$(date -R)"
+  BUILD_DATE="$(date -R)"
 fi
 
 # Run the builds in an isolated source directory.
@@ -18,7 +18,7 @@ cp -a contrib/debian debian || exit 1
 
 # If there's a specific control file for this OS release, use it
 if [ -e "debian/control.${CODENAME}" ]; then
-	cp "debian/control.${CODENAME}" debian/control || exit 1
+  cp "debian/control.${CODENAME}" debian/control || exit 1
 fi
 
 # If the changelog was not updated on the host, assume this is a
@@ -27,10 +27,10 @@ sed -i "s/PREVIOUS_PACKAGE_VERSION/${VERSION}/g" debian/changelog
 sed -i "s/PREVIOUS_PACKAGE_DATE/${BUILD_DATE}/g" debian/changelog
 
 # pre/post options are after 1.18.8, is simpler to just check help for their existence than parsing version
-if dpkg-buildpackage --help | grep "\-\-post\-clean" 2>/dev/null >/dev/null; then
-	dpkg-buildpackage --post-clean --pre-clean -b -us -uc || exit 1
+if dpkg-buildpackage --help | grep "\-\-post\-clean" 2> /dev/null > /dev/null; then
+  dpkg-buildpackage --post-clean --pre-clean -b -us -uc || exit 1
 else
-	dpkg-buildpackage -b -us -uc || exit 1
+  dpkg-buildpackage -b -us -uc || exit 1
 fi
 
 # Copy the built packages to /netdata/artifacts (which may be bind-mounted)


### PR DESCRIPTION
This is the PR that goes along with netdata/netdata#8468 to fix netdata/netdata#8405

This basically consists of a few things:

- Removing the `ARG`(s) as these are notneeded as we only really care about mutating the runtime enviornment for a build not the builder image itself.
- Moving the `COPY` for the `/build.sh1` further down to better utilise the Docker cache
- Add `systemd` as a dependency so the build and packaging system can figure out which version of SystemD to build/package against.