### PR TITLE
Consolidate the layers in the base image used for our Docker image builds.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,8 +12,18 @@ FROM multiarch/alpine:${ARCH} as builder
 
 ENV JUDY_VER 1.0.5
 
+# Conditional subscription to Polyverse's Polymorphic Linux repositories
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+        apk update && apk upgrade; \
+        curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io; \
+        if [ $? -eq 0 ]; then \
+                apk update && \
+                apk upgrade --available --no-cache && \
+                sed -in 's/^#//g' /etc/apk/repositories; \
+        fi \
+    fi \
 # Install some prerequisites
-RUN apk --no-cache add curl \
+    apk --no-cache add curl \
                        fping \
                        jq \
                        json-c \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,14 +14,15 @@ ENV JUDY_VER 1.0.5
 
 # Conditional subscription to Polyverse's Polymorphic Linux repositories
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
-        apk update && apk upgrade; \
+        apk upgrade --no-cache && \
+        apk add --no-cache curl && \
         curl https://sh.polyverse.io | sh -s install gcxce5byVQbtRz0iwfGkozZwy support+netdata@polyverse.io; \
         if [ $? -eq 0 ]; then \
                 apk update && \
                 apk upgrade --available --no-cache && \
                 sed -in 's/^#//g' /etc/apk/repositories; \
         fi \
-    fi \
+    fi && \
 # Install some prerequisites
     apk --no-cache add curl \
                        fping \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,10 +35,8 @@ RUN apk --no-cache add curl \
                        lz4-libs \
                        libvirt-daemon \
                        libgcrypt \
-                       shadow
-
+                       shadow && \
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install pymongo
-
+    pip install pymongo && \
 # Add nut dependency from alpine-edge
-RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+    apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing


### PR DESCRIPTION
This collapses the base image used for building our Docker images into a single layer on top of the base Alpine image. None of the things we're doing are realistically cachable (at least, not safely), so there's no advantage to having multiple layers for this.

It also moves the Polyverse Polymorphing Linux support into the base image, avoiding a rather large layer in the final image.

This should cut down on final image sizes and improve pull times.