### PR TITLE
Add mongo-c-driver-dev library to builder and base image

### DIFF
--- a/.github/scripts/build-base-builder-multiarch-images.sh
+++ b/.github/scripts/build-base-builder-multiarch-images.sh
@@ -33,7 +33,7 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 # Build images using multi-arch Dockerfile.
 for repo in builder base; do
   for ARCH in "${ARCHITECTURES[@]}"; do
-    BUILD_ARCH="${ARCH}-v3.9"
+    BUILD_ARCH="${ARCH}-v3.12"
     echo "Building docker image ${repo}:${BUILD_ARCH}"
     eval docker build \
       --build-arg ARCH="${BUILD_ARCH}" \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,7 +7,7 @@
 
 # This image is used to speed up build process for official netdata images.
 
-ARG ARCH=amd64-v3.9
+ARG ARCH=amd64-v3.12
 FROM multiarch/alpine:${ARCH} as builder
 
 ENV JUDY_VER 1.0.5
@@ -22,11 +22,10 @@ RUN apk --no-cache add curl \
                        lm_sensors \
                        netcat-openbsd \
                        nodejs \
-                       py-mysqldb \
-                       py-psycopg2 \
                        py-yaml \
                        py-pip \
-                       python \
+                       python3 \
+                       python3-dev \
                        util-linux \
                        zlib \
                        libuv \
@@ -35,13 +34,15 @@ RUN apk --no-cache add curl \
                        lz4-libs \
                        libvirt-daemon \
                        libgcrypt \
-                       shadow
-
-# Dependency for mongoDB exporter
-RUN apk --no-cache add --upgrade mongo-c-driver-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.11/community/
+                       shadow \
+                       mariadb-dev \
+                       postgresql-dev \
+                       gcc \
+                       musl-dev \
+                       mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install pymongo
+RUN pip install pymongo mysqlclient psycopg2
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -41,7 +41,7 @@ RUN apk --no-cache add curl \
                        mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install pymongo mysqlclient psycopg2 PyYAML
+RUN pip install pymongo mysqlclient psycopg2
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -37,6 +37,9 @@ RUN apk --no-cache add curl \
                        libgcrypt \
                        shadow
 
+# Dependency for mongoDB exporter
+RUN apk --no-cache add --upgrade mongo-c-driver-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.11/community/
+
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
 RUN pip install pymongo
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,7 +22,6 @@ RUN apk --no-cache add curl \
                        lm_sensors \
                        netcat-openbsd \
                        nodejs \
-                       py-yaml \
                        py-pip \
                        python3 \
                        python3-dev \
@@ -42,7 +41,7 @@ RUN apk --no-cache add curl \
                        mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install pymongo mysqlclient psycopg2
+RUN pip install pymongo mysqlclient psycopg2 PyYAML
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -21,7 +21,6 @@ RUN apk --no-cache add alpine-sdk \
                        netcat-openbsd \
                        nodejs \
                        pkgconfig \
-                       py-yaml \
                        py-pip \
                        python3 \
                        python3-dev \
@@ -36,7 +35,7 @@ RUN apk --no-cache add alpine-sdk \
                        mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install mysqlclient 
+RUN pip install mysqlclient PyYAML
 
 # Instaling psycopg2 requires additional alpine packages
 # Removing dependencies again after psycopg2 has been installed

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -3,7 +3,7 @@
 
 # This image is used to speed up build process for official netdata images.
 
-ARG ARCH=amd64-v3.9
+ARG ARCH=amd64-v3.12
 FROM multiarch/alpine:${ARCH} as builder
 
 # Install prerequisites
@@ -21,20 +21,31 @@ RUN apk --no-cache add alpine-sdk \
                        netcat-openbsd \
                        nodejs \
                        pkgconfig \
-                       py-mysqldb \
-                       py-psycopg2 \
                        py-yaml \
-                       python \
+                       py-pip \
+                       python3 \
+                       python3-dev \
                        util-linux-dev \
                        zlib-dev \
                        libuv-dev \
                        lz4-dev \
                        openssl-dev \
                        libgcrypt-dev \
-                       cmake
+                       mariadb-dev \
+                       cmake \
+                       mongo-c-driver-dev
 
-# Dependencies to build libmongoc
-RUN apk --no-cache add --upgrade mongo-c-driver-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.11/community/
+# Add Python dependencies from PyPi using `pip` we have not APK(s) for:
+RUN pip install mysqlclient 
+
+# Instaling psycopg2 requires additional alpine packages
+# Removing dependencies again after psycopg2 has been installed
+RUN apk add --no-cache --virtual .build-deps \
+    gcc \
+    musl-dev \
+    postgresql-dev \
+    && pip install --no-cache-dir psycopg2 \
+    && apk del --no-cache .build-deps
 
 # External dependencies (bundled to avoid network access)
 COPY deps /deps

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -33,6 +33,9 @@ RUN apk --no-cache add alpine-sdk \
                        libgcrypt-dev \
                        cmake
 
+# Dependencies to build libmongoc
+RUN apk --no-cache add --upgrade mongo-c-driver-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.11/community/
+
 # External dependencies (bundled to avoid network access)
 COPY deps /deps
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --no-cache add alpine-sdk \
                        mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install mysqlclient PyYAML
+RUN pip install mysqlclient
 
 # Instaling psycopg2 requires additional alpine packages
 # Removing dependencies again after psycopg2 has been installed

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -23,7 +23,8 @@ RUN yum install -y 'dnf-command(config-manager)' && \
                    git \
                    json-c-devel \
                    # XXX: Upstream package in PowerTools is broken/missing but its there to be downloaded *shrugs*
-                   http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.1.0+217+4d875839.x86_64.rpm \
+                   #http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.1.0+217+4d875839.x86_64.rpm \
+                   https://rpmfind.net/linux/centos/8-stream/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.1.0+217+4d875839.x86_64.rpm \
                    libmnl-devel \
                    # FIXME: broken / Missing
                    # XXX: Can't (currently) find a CentOS 8 package for this :/


### PR DESCRIPTION
To also support the mongoDB export feature of NetData, the mongo-c-driver-dev package is required.

This PR refers to this Issue [#9479](https://github.com/netdata/netdata/issues/9479) from the netdata/netdata Repository.