### PR TITLE
Add msmtp to base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -38,6 +38,7 @@ RUN apk --no-cache add curl \
                        postgresql-dev \
                        gcc \
                        musl-dev \
+                       msmtp \
                        mongo-c-driver-dev
 
 # Add Python dependencies from PyPi using `pip` we have not APK(s) for:


### PR DESCRIPTION
Add `msmtp` package for sending emails via smtp + tls

Docs: https://learn.netdata.cloud/docs/agent/health/notifications/email