### PR TITLE
Fix netdata/netdata Docker image size

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,9 +22,6 @@ RUN apk --no-cache add curl \
                        lm_sensors \
                        netcat-openbsd \
                        nodejs \
-                       py-pip \
-                       python3 \
-                       python3-dev \
                        util-linux \
                        zlib \
                        libuv \
@@ -34,15 +31,11 @@ RUN apk --no-cache add curl \
                        libvirt-daemon \
                        libgcrypt \
                        shadow \
-                       mariadb-dev \
-                       postgresql-dev \
-                       gcc \
-                       musl-dev \
                        msmtp \
-                       mongo-c-driver-dev
-
-# Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install pymongo mysqlclient psycopg2
+                       postgresql-client \
+                       mongo-c-driver \
+                       python3 \
+                       py3-pip
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,0 +1,3 @@
+pymongo
+mysqlclient
+psycopg2

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -32,7 +32,6 @@ RUN apk --no-cache add alpine-sdk \
                        libgcrypt-dev \
                        mariadb-dev \
                        cmake \
-                       gcc \
                        musl-dev \
                        postgresql-dev \
                        mongo-c-driver-dev

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -21,7 +21,7 @@ RUN apk --no-cache add alpine-sdk \
                        netcat-openbsd \
                        nodejs \
                        pkgconfig \
-                       py-pip \
+                       py3-pip \
                        python3 \
                        python3-dev \
                        util-linux-dev \
@@ -32,19 +32,15 @@ RUN apk --no-cache add alpine-sdk \
                        libgcrypt-dev \
                        mariadb-dev \
                        cmake \
+                       gcc \
+                       musl-dev \
+                       postgresql-dev \
                        mongo-c-driver-dev
 
-# Add Python dependencies from PyPi using `pip` we have not APK(s) for:
-RUN pip install mysqlclient
-
-# Instaling psycopg2 requires additional alpine packages
-# Removing dependencies again after psycopg2 has been installed
-RUN apk add --no-cache --virtual .build-deps \
-    gcc \
-    musl-dev \
-    postgresql-dev \
-    && pip install --no-cache-dir psycopg2 \
-    && apk del --no-cache .build-deps
+# Add Python dependencies from PyPi using `pip`
+COPY builder/requirements.txt /tmp/requirements.txt
+RUN pip install wheel && \
+    pip wheel -w /wheels -r /tmp/requirements.txt
 
 # External dependencies (bundled to avoid network access)
 COPY deps /deps

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,0 +1,2 @@
+pymongo
+psycopg2


### PR DESCRIPTION
Refactos the base/builder Docker images to ensure that we build Python
dependencies as Wheel(s) (_binary Python pakcages_), do this in the builder
image and only ensure we only have runtime dependencies in the base image.