### PR TITLE
Add libtool to our builder image.

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -16,6 +16,7 @@ RUN apk --no-cache add alpine-sdk \
                        jq \
                        json-c-dev \
                        libmnl-dev \
+                       libtool \
                        libuuid \
                        lm_sensors \
                        netcat-openbsd \


### PR DESCRIPTION
It's needed by the libJudy build process in our new bundling code.

Required to fix the Docker build checks for https://github.com/netdata/netdata/pull/9776