### PR TITLE
Stop bundling Judy in the builder image.

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -45,26 +45,6 @@ RUN pip install wheel && \
 # External dependencies (bundled to avoid network access)
 COPY deps /deps
 
-# Judy doesnt seem to be available on the repositories, download manually and install it
-ENV JUDY_VER 1.0.5
-RUN if [ "${ARCH}" == "aarch64" ]; then \
-    echo "Executing ${ARCH} build, adding exceptional option --build for judy" \
-    && cp /deps/Judy-${JUDY_VER}.tar.gz /judy.tar.gz \
-    && cd / && tar -xf judy.tar.gz && rm judy.tar.gz \
-    && cd /judy-${JUDY_VER} \
-    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure --build=aarch64-unknown-linux-gnu --prefix=/deps \
-    && make \
-    && make install; \
-    # non aarch64 branch
-    else \
-    cp /deps/Judy-${JUDY_VER}.tar.gz /judy.tar.gz \
-    && cd / && tar -xf judy.tar.gz && rm judy.tar.gz \
-    && cd /judy-${JUDY_VER} \
-    && CFLAGS="-O2 -s" CXXFLAGS="-O2 -s" ./configure --prefix=/deps \
-    && make \
-    && make install; \
-    fi;
-
 # freeipmi
 ENV FREEIPMI_VER 1.6.4
 COPY builder/patches/freeipmi-argp-redefine.patch /freeipmi-${FREEIPMI_VER}/


### PR DESCRIPTION
In the interest of better consistency with the other installation methods, this PR removes the bundling of libJudy that we were doing for our Docker images so that we use the code from https://github.com/netdata/netdata/pull/9776 instead. This will shorten the build timesfor our builder images, but slightly lengthen the total build time for our actual Docker images, but should make any issues relating to libJudy easier to debug as well as ensuring we're 100% consistent with how we handle libJudy on Alpine systems in general.