### PR TITLE
Snappy & protobuf installation in docker image in order to use "Prometheus remote write"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -35,7 +35,9 @@ RUN apk --no-cache add curl \
                        postgresql-client \
                        mongo-c-driver \
                        python3 \
-                       py3-pip
+                       py3-pip \
+                       protobuf \
+                       snappy
 
 # Add nut dependency from alpine-edge
 RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -36,8 +36,8 @@ RUN apk --no-cache add alpine-sdk \
                        musl-dev \
                        postgresql-dev \
                        mongo-c-driver-dev \
-                       protobuf \
-                       snappy
+                       protobuf-dev \
+                       snappy-dev
 
 # Add Python dependencies from PyPi using `pip`
 COPY builder/requirements.txt /tmp/requirements.txt

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -35,7 +35,9 @@ RUN apk --no-cache add alpine-sdk \
                        cmake \
                        musl-dev \
                        postgresql-dev \
-                       mongo-c-driver-dev
+                       mongo-c-driver-dev \
+                       protobuf \
+                       snappy
 
 # Add Python dependencies from PyPi using `pip`
 COPY builder/requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
I am trying to use the [promethus remote write](https://learn.netdata.cloud/docs/agent/exporting/prometheus/remote_write) functionality, but it says that I need to install snappy & protobuf and re-install netdata from source. However, I do not see such dependencies in [the netdata dockerfile](https://github.com/netdata/netdata/blob/master/packaging/docker/Dockerfile), neither do I see from [netdata:builder](https://hub.docker.com/r/netdata/builder/dockerfile) (or [here](https://github.com/netdata/helper-images/blob/master/builder/Dockerfile)). After some help from the kind maintainers, I try to create this PR to fix this problem.

See: https://github.com/netdata/netdata/issues/9851