### PR TITLE
Add `tc` command to our Docker images.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -30,6 +30,7 @@ RUN apk --no-cache add curl \
                        lz4-libs \
                        libvirt-daemon \
                        libgcrypt \
+                       iproute2 \
                        shadow \
                        msmtp \
                        postgresql-client \


### PR DESCRIPTION
This allows QoS monitoring to work correctly in a container.

Fixes: https://github.com/netdata/netdata/issues/9861