### PR TITLE
Add edge/main repository when installing nut

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -41,4 +41,4 @@ RUN apk --no-cache add curl \
                        snappy
 
 # Add nut dependency from alpine-edge
-RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add nut lm-sensors --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -41,4 +41,4 @@ RUN apk --no-cache add curl \
                        snappy
 
 # Add nut dependency from alpine-edge
-RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main


### PR DESCRIPTION
Fixes #91 by adding the `edge/main` repo to the nut installation `apk` invocation such that it can find the `net-snmp-libs` package (which has moved from `edge/testing` to `edge/main`.