### PR TITLE
Update actions workflows to use official Docker actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /base
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /builder
+    schedule:
+      interval: weekly

--- a/.github/workflows/base-builder.yml
+++ b/.github/workflows/base-builder.yml
@@ -15,18 +15,36 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch:
-          - i386
-          - armhf
-          - aarch64
-          - amd64
+        image:
+          - base
+          - builder
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run build.sh
-        env:
-          DOCKER_USERNAME: netdatabot
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          ARCH: ${{ matrix.arch }}
-        run: |
-          ./.github/scripts/build-base-builder-multiarch-images.sh
+      - name: Check if we should push images
+        if: (github.event_name == 'schedule' || github.event_name == 'push')
+        run: echo 'PUSH_IMAGES=true' >> $GITHUB_ENV
+      - name: Check if we should push images
+        if: github.event_name == 'pull_request'
+        run: echo 'PUSH_IMAGES=false' >> $GITHUB_ENV
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Hub Login
+        if: env.PUSH_IMAGES == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: netdatabot
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/i386,linux/arm/v7,linux/arm64
+          push: ${{ env.PUSH_IMAGES }}
+          file: ./${{ matrix.image }}/Dockerfile
+          tags: |
+            netdata/${{ matrix.image }}:amd64
+            netdata/${{ matrix.image }}:i386
+            netdata/${{ matrix.image }}:armhf
+            netdata/${{ matrix.image }}:aarch64

--- a/.github/workflows/oses.yml
+++ b/.github/workflows/oses.yml
@@ -35,14 +35,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build
-        run: |
-          docker build -f ./oses/Dockerfile.${{ matrix.os}} -t netdata/os-test:${{ matrix.os }} ./
-      - name: Publish
-        if: (github.event_name == 'schedule' || github.event_name == 'push') && github.repository == 'netdata/helper-images'
-        env:
-          DOCKER_USERNAME: netdatabot
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-          docker push netdata/os-test:${{ matrix.os }}
+      - name: Check if we should push images
+        if: (github.event_name == 'schedule' || github.event_name == 'push')
+        run: echo 'PUSH_IMAGES=true' >> $GITHUB_ENV
+      - name: Check if we should push images
+        if: github.event_name == 'pull_request'
+        run: echo 'PUSH_IMAGES=false' >> $GITHUB_ENV
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Hub Login
+        if: env.PUSH_IMAGES == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: netdatabot
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          push: ${{ env.PUSH_IMAGES }}
+          file: ./oses/Dockerfile.${{ matrix.os }}
+          tags: netdata/os-test:${{ matrix.os }}

--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -17,12 +17,9 @@ jobs:
         os:
           - centos7
           - centos8
-          - debian11
-          - debian11_i386
-          - debian10
-          - debian10_i386
           - debian9
-          - debian9_i386
+          - debian10
+          - debian11
           - fedora32
           - fedora33
           - opensuse15.1
@@ -33,18 +30,57 @@ jobs:
           - ubuntu18.04_i386
           - ubuntu20.04
           - ubuntu20.10
+        include:
+          - distro: centos7
+            arches: linux/amd64
+          - distro: centos8
+            arches: linux/amd64
+          - distro: debian9
+            arches: linux/amd64,linux/i386
+          - distro: debian10
+            arches: linux/amd64,linux/i386
+          - distro: debian11
+            arches: linux/amd64,linux/i386
+          - distro: fedora32
+            arches: linux/amd64
+          - distro: fedora33
+            arches: linux/amd64
+          - distro: opensuse15.1
+            arches: linux/amd64
+          - distro: opensuse15.2
+            arches: linux/amd64
+          - distro: ubuntu16.04
+            arches: linux/amd64,linux/i386
+          - distro: ubuntu18.04
+            arches: linux/amd64,linux/i386
+          - distro: ubuntu20.04
+            arches: linux/amd64
+          - distro: ubuntu20.10
+            arches: linux/amd64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Build
-        run: |
-          docker build -f ./package-builders/Dockerfile.${{ matrix.os }} -t netdata/package-builders:${{ matrix.os }} ./
-      - name: Publish
+      - name: Check if we should push images
         if: (github.event_name == 'schedule' || github.event_name == 'push') && github.repository == 'netdata/helper-images'
-        env:
-          DOCKER_USERNAME: netdatabot
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-          docker push netdata/package-builders:${{ matrix.os }}
+        run: echo 'PUSH_IMAGES=true' >> $GITHUB_ENV
+      - name: Check if we should push images
+        if: github.event_name == 'pull_request' || github.repository != 'netdata/helper-images'
+        run: echo 'PUSH_IMAGES=false' >> $GITHUB_ENV
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Hub Login
+        if: env.PUSH_IMAGES == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: netdatabot
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          platforms: ${{ matrix.arches }}
+          push: ${{ env.PUSH_IMAGES }}
+          file: ./package-builders/Dockerfile.${{ matrix.os }}
+          tags: netdata/package-builders:${{ matrix.os }}

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,16 +1,14 @@
 # This image is used to speed up build process for official netdata images.
 #
-# Copyright: SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright: 2019 and later Netdata Incorporated
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Author : paulfantom
 # Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
+# Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
 # This image is used to speed up build process for official netdata images.
 
-ARG ARCH=amd64-v3.12
-FROM multiarch/alpine:${ARCH} as builder
-
-ENV JUDY_VER 1.0.5
+FROM alpine:3.12 as builder
 
 # Install some prerequisites
 RUN apk --no-cache add curl \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -50,15 +50,11 @@ COPY deps /deps
 # freeipmi
 ENV FREEIPMI_VER 1.6.4
 COPY builder/patches/freeipmi-argp-redefine.patch /freeipmi-${FREEIPMI_VER}/
-RUN cp /deps/freeipmi-${FREEIPMI_VER}.tar.gz /freeipmi.tar.gz \
-    && cd / \
-    && tar -xf freeipmi.tar.gz \
-    && rm freeipmi.tar.gz \
+RUN tar -xf /deps/freeipmi-${FREEIPMI_VER}.tar.gz -C /\
     && cd /freeipmi-${FREEIPMI_VER} \
     && patch -p 0 < freeipmi-argp-redefine.patch \
     && rm freeipmi-argp-redefine.patch \
-    && CPPFLAGS="-Dgetmsg\(a,b,c,d\)=errno=-1,-1 -Dputmsg\(a,b,c,d\)=errno=-1,-1" ./configure --prefix=/deps \
-    && make \
+    && CPPFLAGS="-Dgetmsg\(a,b,c,d\)=errno=-1,-1 -Dputmsg\(a,b,c,d\)=errno=-1,-1" ./configure --prefix=/deps --disable-dependency-tracking --with-gnu-ld \
+    && make -j2 \
     && make install \
-    && cd / \
     && rm -rf /freeipmi-${FREEIPMI_VER}

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # author  : paulfantom
+# author  : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
 # This image is used to speed up build process for official netdata images.
 
-ARG ARCH=amd64-v3.12
-FROM multiarch/alpine:${ARCH} as builder
+FROM alpine:3.12 as builder
 
 # Install prerequisites
 RUN apk --no-cache add alpine-sdk \

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -2,12 +2,12 @@ FROM centos:8
 
 ENV VERSION=$VERSION
 
-RUN yum install -y 'dnf-command(config-manager)' && \
-    yum config-manager --set-enabled PowerTools && \
-    yum install -y epel-release && \
-    yum install -y http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm && \
-    yum update -y && \
-    yum install -y autoconf \
+RUN dnf update -y && \
+    dnf install -y epel-release && \
+    dnf install -y http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm && \
+    dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y autoconf \
                    autoconf-archive \
                    autogen \
                    automake \
@@ -49,7 +49,7 @@ RUN yum install -y 'dnf-command(config-manager)' && \
                    snappy-devel \
                    wget \
                    zlib-devel && \
-    yum clean all && \
+    dnf clean all && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This makes the workflows themselves much simpler, increases parallelism of the image builds, enables us to use the regular Alpine images as bases instead of the custom multiarch ones, and will make things much more maintainable.

It also adds configuration to leverage Dependabot to automatically open PRs to keep our GHA workflows updated, as well as the base and builder Docker images, and additionally does some optimization in the Dockerfile for the builder image to cut down on how long it takes to build the image (which is important because of how the new image building and publishing CI/CD works).