### PR TITLE
Explicitly push `latest` tag for base and builder images.

### DIFF
--- a/.github/workflows/base-builder.yml
+++ b/.github/workflows/base-builder.yml
@@ -48,3 +48,4 @@ jobs:
             netdata/${{ matrix.image }}:i386
             netdata/${{ matrix.image }}:armhf
             netdata/${{ matrix.image }}:aarch64
+            netdata/${{ matrix.image }}:latest


### PR DESCRIPTION
We will eventually pivot to using this instead of the architecture tags for our actual image builds.

This was unfortunately missed with the CI updates to use official Docker actions.