### PR TITLE
AAdd build caching for base and builder images.

### DIFF
--- a/.github/workflows/base-builder.yml
+++ b/.github/workflows/base-builder.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           username: netdatabot
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.image }}
       - name: Docker Build
         uses: docker/build-push-action@v2
         with:
@@ -49,3 +54,9 @@ jobs:
             netdata/${{ matrix.image }}:armhf
             netdata/${{ matrix.image }}:aarch64
             netdata/${{ matrix.image }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Cleanup Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
This updates the base and builder image build workflows to leverage the Docker registry for caching. This has a number of tangible benefits:

* CI checks for these images should run much faster.
* Actual builds for deployment of these images should run much faster in most cases.
* Because we’re properly reusing cached layer information, users should need to pull fewer layers when updating their copies of Docker images.

These benefits will require at least 48 hours to be realized however, as the existing images do not have the relevant caching information embedded.