### PR TITLE
Add ARM package builder images.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -29,29 +29,29 @@ jobs:
           - ubuntu20.10
         include:
           - os: centos7
-            arches: linux/amd64
+            arches: linux/amd64 # Unable to provide alternate arches due to our dependence on OKay.
           - os: centos8
-            arches: linux/amd64
+            arches: linux/amd64 # Unable to provide alternate arches due to our dependence on OKay.
           - os: debian9
-            arches: linux/amd64,linux/i386
+            arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linuxs390x,linux/mips64le,linux/arm/v5
           - os: debian10
-            arches: linux/amd64,linux/i386
+            arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linuxs390x,linux/mips64le,linux/arm/v5
           - os: debian11
-            arches: linux/amd64,linux/i386
+            arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linuxs390x,linux/mips64le,linux/arm/v5
           - os: fedora32
-            arches: linux/amd64
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: fedora33
-            arches: linux/amd64
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: opensuse15.2
-            arches: linux/amd64
+            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
           - os: ubuntu16.04
-            arches: linux/amd64,linux/i386
+            arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu18.04
-            arches: linux/amd64,linux/i386
+            arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu20.04
-            arches: linux/amd64
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu20.10
-            arches: linux/amd64
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -2,55 +2,56 @@ FROM centos:8
 
 ENV VERSION=$VERSION
 
-RUN dnf update -y && \
-    dnf install -y epel-release && \
-    dnf install -y http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm && \
-    dnf install -y 'dnf-command(config-manager)' && \
+RUN dnf distro-sync -y --nodocs && \
+    dnf install -y --nodocs epel-release && \
+    dnf install -y --nodocs http://repo.okay.com.mx/centos/8/x86_64/release/okay-release-1-3.el8.noarch.rpm && \
+    dnf install -y --nodocs 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools && \
-    dnf install -y autoconf \
-                   autoconf-archive \
-                   autogen \
-                   automake \
-                   bash \
-                   cmake \
-                   cups-devel \
-                   curl \
-                   diffutils \
-                   elfutils-libelf-devel \
-                   findutils \
-                   freeipmi-devel \
-                   gcc \
-                   gcc-c++ \
-                   git \
-                   json-c-devel \
-                   libmnl-devel \
-                   # FIXME: broken / Missing
-                   # XXX: Can't (currently) find a CentOS 8 package for this :/
-                   #libnetfilter_acct-devel \
-                   libtool \
-                   libuuid-devel \
-                   libwebsockets-devel \
-                   libuv-devel \
-                   lm_sensors \
-                   lz4-devel \
-                   make \
-                   nc \
-                   openssl-devel \
-                   patch \
-                   pkgconfig \
-                   procps \
-                   protobuf-c-devel \
-                   protobuf-compiler \
-                   protobuf-devel \
-                   python3 \
-                   python3-pyyaml \
-                   rpm-build \
-                   rpm-devel \
-                   rpmdevtools \
-                   snappy-devel \
-                   wget \
-                   zlib-devel && \
-    dnf clean all && \
+    dnf clean packages && \
+    dnf install -y --nodocs autoconf \
+                            autoconf-archive \
+                            autogen \
+                            automake \
+                            bash \
+                            cmake \
+                            cups-devel \
+                            curl \
+                            diffutils \
+                            elfutils-libelf-devel \
+                            findutils \
+                            freeipmi-devel \
+                            gcc \
+                            gcc-c++ \
+                            git \
+                            json-c-devel \
+                            libmnl-devel \
+                            # FIXME: broken / Missing
+                            # XXX: Can't (currently) find a CentOS 8 package for this :/
+                            #libnetfilter_acct-devel \
+                            libtool \
+                            libuuid-devel \
+                            libwebsockets-devel \
+                            libuv-devel \
+                            lm_sensors \
+                            lz4-devel \
+                            make \
+                            nc \
+                            openssl-devel \
+                            patch \
+                            pkgconfig \
+                            procps \
+                            protobuf-c-devel \
+                            protobuf-compiler \
+                            protobuf-devel \
+                            python3 \
+                            python3-pyyaml \
+                            rpm-build \
+                            rpm-devel \
+                            rpmdevtools \
+                            snappy-devel \
+                            wget \
+                            zlib-devel && \
+    rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -8,7 +8,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools && \
     dnf clean packages && \
-    dnf install -y --nodocs --setopt=install_weak_deps=False \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         autoconf \
         autoconf-archive \
         autogen \

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -8,49 +8,50 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools && \
     dnf clean packages && \
-    dnf install -y --nodocs autoconf \
-                            autoconf-archive \
-                            autogen \
-                            automake \
-                            bash \
-                            cmake \
-                            cups-devel \
-                            curl \
-                            diffutils \
-                            elfutils-libelf-devel \
-                            findutils \
-                            freeipmi-devel \
-                            gcc \
-                            gcc-c++ \
-                            git \
-                            json-c-devel \
-                            libmnl-devel \
-                            # FIXME: broken / Missing
-                            # XXX: Can't (currently) find a CentOS 8 package for this :/
-                            #libnetfilter_acct-devel \
-                            libtool \
-                            libuuid-devel \
-                            libwebsockets-devel \
-                            libuv-devel \
-                            lm_sensors \
-                            lz4-devel \
-                            make \
-                            nc \
-                            openssl-devel \
-                            patch \
-                            pkgconfig \
-                            procps \
-                            protobuf-c-devel \
-                            protobuf-compiler \
-                            protobuf-devel \
-                            python3 \
-                            python3-pyyaml \
-                            rpm-build \
-                            rpm-devel \
-                            rpmdevtools \
-                            snappy-devel \
-                            wget \
-                            zlib-devel && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git \
+        json-c-devel \
+        libmnl-devel \
+        # FIXME: broken / Missing
+        # XXX: Can't (currently) find a CentOS 8 package for this :/
+        #libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libwebsockets-devel \
+        libuv-devel \
+        lm_sensors \
+        lz4-devel \
+        make \
+        nc \
+        openssl-devel \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-pyyaml \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
     rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 

--- a/package-builders/Dockerfile.fedora32
+++ b/package-builders/Dockerfile.fedora32
@@ -2,46 +2,47 @@ FROM fedora:32
 
 ENV VERSION=$VERSION
 
-RUN dnf update -y && \
-    dnf install -y autoconf \
-                   autoconf-archive \
-                   autogen \
-                   automake \
-                   bash \
-                   cmake \
-                   cups-devel \
-                   curl \
-                   diffutils \
-                   elfutils-libelf-devel \
-                   findutils \
-                   freeipmi-devel \
-                   gcc \
-                   gcc-c++ \
-                   git-core \
-                   json-c-devel \
-                   Judy-devel \
-                   libmnl-devel \
-                   libnetfilter_acct-devel \
-                   libtool \
-                   libuuid-devel \
-                   libuv-devel \
-                   libwebsockets-devel \
-                   lm_sensors \
-                   lz4-devel \
-                   make \
-                   openssl-devel \
-                   patch \
-                   pkgconfig \
-                   procps \
-                   protobuf-c-devel \
-                   protobuf-compiler \
-                   protobuf-devel \
-                   rpm-build \
-                   rpm-devel \
-                   rpmdevtools \
-                   snappy-devel \
-                   wget \
-                   zlib-devel && \
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs autoconf \
+                            autoconf-archive \
+                            autogen \
+                            automake \
+                            bash \
+                            cmake \
+                            cups-devel \
+                            curl \
+                            diffutils \
+                            elfutils-libelf-devel \
+                            findutils \
+                            freeipmi-devel \
+                            gcc \
+                            gcc-c++ \
+                            git-core \
+                            json-c-devel \
+                            Judy-devel \
+                            libmnl-devel \
+                            libnetfilter_acct-devel \
+                            libtool \
+                            libuuid-devel \
+                            libuv-devel \
+                            libwebsockets-devel \
+                            lm_sensors \
+                            lz4-devel \
+                            make \
+                            openssl-devel \
+                            patch \
+                            pkgconfig \
+                            procps \
+                            protobuf-c-devel \
+                            protobuf-compiler \
+                            protobuf-devel \
+                            rpm-build \
+                            rpm-devel \
+                            rpmdevtools \
+                            snappy-devel \
+                            wget \
+                            zlib-devel && \
     rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 

--- a/package-builders/Dockerfile.fedora32
+++ b/package-builders/Dockerfile.fedora32
@@ -4,7 +4,7 @@ ENV VERSION=$VERSION
 
 RUN dnf distro-sync -y --nodocs && \
     dnf clean -y packages && \
-    dnf install -y --nodocs --setopt=install_weak_deps=False \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         autoconf \
         autoconf-archive \
         autogen \

--- a/package-builders/Dockerfile.fedora32
+++ b/package-builders/Dockerfile.fedora32
@@ -4,45 +4,45 @@ ENV VERSION=$VERSION
 
 RUN dnf distro-sync -y --nodocs && \
     dnf clean -y packages && \
-    dnf install -y --nodocs autoconf \
-                            autoconf-archive \
-                            autogen \
-                            automake \
-                            bash \
-                            cmake \
-                            cups-devel \
-                            curl \
-                            diffutils \
-                            elfutils-libelf-devel \
-                            findutils \
-                            freeipmi-devel \
-                            gcc \
-                            gcc-c++ \
-                            git-core \
-                            json-c-devel \
-                            Judy-devel \
-                            libmnl-devel \
-                            libnetfilter_acct-devel \
-                            libtool \
-                            libuuid-devel \
-                            libuv-devel \
-                            libwebsockets-devel \
-                            lm_sensors \
-                            lz4-devel \
-                            make \
-                            openssl-devel \
-                            patch \
-                            pkgconfig \
-                            procps \
-                            protobuf-c-devel \
-                            protobuf-compiler \
-                            protobuf-devel \
-                            rpm-build \
-                            rpm-devel \
-                            rpmdevtools \
-                            snappy-devel \
-                            wget \
-                            zlib-devel && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        json-c-devel \
+        Judy-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        libwebsockets-devel \
+        lz4-devel \
+        make \
+        openssl-devel \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
     rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 

--- a/package-builders/Dockerfile.fedora33
+++ b/package-builders/Dockerfile.fedora33
@@ -2,46 +2,47 @@ FROM fedora:33
 
 ENV VERSION=$VERSION
 
-RUN dnf update -y && \
-    dnf install -y autoconf \
-                   autoconf-archive \
-                   autogen \
-                   automake \
-                   bash \
-                   cmake \
-                   cups-devel \
-                   curl \
-                   diffutils \
-                   elfutils-libelf-devel \
-                   findutils \
-                   freeipmi-devel \
-                   gcc \
-                   gcc-c++ \
-                   git-core \
-                   json-c-devel \
-                   Judy-devel \
-                   libmnl-devel \
-                   libnetfilter_acct-devel \
-                   libtool \
-                   libuuid-devel \
-                   libuv-devel \
-                   libwebsockets-devel \
-                   lm_sensors \
-                   lz4-devel \
-                   make \
-                   openssl-devel \
-                   patch \
-                   pkgconfig \
-                   procps \
-                   protobuf-c-devel \
-                   protobuf-compiler \
-                   protobuf-devel \
-                   rpm-build \
-                   rpm-devel \
-                   rpmdevtools \
-                   snappy-devel \
-                   wget \
-                   zlib-devel && \
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs autoconf \
+                            autoconf-archive \
+                            autogen \
+                            automake \
+                            bash \
+                            cmake \
+                            cups-devel \
+                            curl \
+                            diffutils \
+                            elfutils-libelf-devel \
+                            findutils \
+                            freeipmi-devel \
+                            gcc \
+                            gcc-c++ \
+                            git-core \
+                            json-c-devel \
+                            Judy-devel \
+                            libmnl-devel \
+                            libnetfilter_acct-devel \
+                            libtool \
+                            libuuid-devel \
+                            libuv-devel \
+                            libwebsockets-devel \
+                            lm_sensors \
+                            lz4-devel \
+                            make \
+                            openssl-devel \
+                            patch \
+                            pkgconfig \
+                            procps \
+                            protobuf-c-devel \
+                            protobuf-compiler \
+                            protobuf-devel \
+                            rpm-build \
+                            rpm-devel \
+                            rpmdevtools \
+                            snappy-devel \
+                            wget \
+                            zlib-devel && \
     rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 

--- a/package-builders/Dockerfile.fedora33
+++ b/package-builders/Dockerfile.fedora33
@@ -4,7 +4,7 @@ ENV VERSION=$VERSION
 
 RUN dnf distro-sync -y --nodocs && \
     dnf clean -y packages && \
-    dnf install -y --nodocs --setopt=install_weak_deps=False \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         autoconf \
         autoconf-archive \
         autogen \

--- a/package-builders/Dockerfile.fedora33
+++ b/package-builders/Dockerfile.fedora33
@@ -4,45 +4,45 @@ ENV VERSION=$VERSION
 
 RUN dnf distro-sync -y --nodocs && \
     dnf clean -y packages && \
-    dnf install -y --nodocs autoconf \
-                            autoconf-archive \
-                            autogen \
-                            automake \
-                            bash \
-                            cmake \
-                            cups-devel \
-                            curl \
-                            diffutils \
-                            elfutils-libelf-devel \
-                            findutils \
-                            freeipmi-devel \
-                            gcc \
-                            gcc-c++ \
-                            git-core \
-                            json-c-devel \
-                            Judy-devel \
-                            libmnl-devel \
-                            libnetfilter_acct-devel \
-                            libtool \
-                            libuuid-devel \
-                            libuv-devel \
-                            libwebsockets-devel \
-                            lm_sensors \
-                            lz4-devel \
-                            make \
-                            openssl-devel \
-                            patch \
-                            pkgconfig \
-                            procps \
-                            protobuf-c-devel \
-                            protobuf-compiler \
-                            protobuf-devel \
-                            rpm-build \
-                            rpm-devel \
-                            rpmdevtools \
-                            snappy-devel \
-                            wget \
-                            zlib-devel && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        json-c-devel \
+        Judy-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        libwebsockets-devel \
+        lz4-devel \
+        make \
+        openssl-devel \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
     rm -rf /var/cache/dnf && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 


### PR DESCRIPTION
Also adds comments listing other possible architectures for each distro.

This does not add any additional platforms for CentOS as we are dependent on a repository that is only available for x86 systems.

We’ll probably eventually add POWER8 (`linux/ppc64le`) and System/Z (`linux/s390x`) support as well, but those need proper testing that has not yet been done.