### PR TITLE
Add Ubuntu 21.04 and Fedora 34 package builder images.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -22,11 +22,13 @@ jobs:
           - debian11
           - fedora32
           - fedora33
+          - fedora34
           - opensuse15.2
           - ubuntu16.04
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu20.10
+          - ubuntu21.04
         include:
           - os: centos7
             arches: linux/amd64 # Unable to provide alternate arches due to our dependence on OKay.
@@ -42,6 +44,8 @@ jobs:
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: fedora33
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
+          - os: fedora34
+            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: opensuse15.2
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
           - os: ubuntu16.04
@@ -51,6 +55,8 @@ jobs:
           - os: ubuntu20.04
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu20.10
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
+          - os: ubuntu21.04
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
     runs-on: ubuntu-latest
     steps:

--- a/package-builders/Dockerfile.fedora34
+++ b/package-builders/Dockerfile.fedora34
@@ -1,0 +1,53 @@
+FROM fedora:33
+
+ENV VERSION=$VERSION
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        json-c-devel \
+        Judy-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        libwebsockets-devel \
+        lz4-devel \
+        make \
+        openssl-devel \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu21.04
+++ b/package-builders/Dockerfile.ubuntu21.04
@@ -1,0 +1,56 @@
+FROM ubuntu:20.10
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git-core \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libtool \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/debian-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]


### PR DESCRIPTION
Planned release of Ubuntu 21.04 is 2021-04-22.

Planned release of Fedora 34 is 2021-04-20.

This PR should ideally be merged prior to then so that we can have binary package support for both on day one.