### PR TITLE
Explicitly run `c_rehash` when building the package builders.

### DIFF
--- a/package-builders/Dockerfile.centos7
+++ b/package-builders/Dockerfile.centos7
@@ -32,6 +32,7 @@ RUN yum install -y epel-release && \
                    lz4-devel \
                    make \
                    openssl-devel \
+                   openssl-perl \
                    patch \
                    pkgconfig \
                    procps \
@@ -45,6 +46,7 @@ RUN yum install -y epel-release && \
                    wget \
                    zlib-devel && \
     yum clean all && \
+    c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.centos8
+++ b/package-builders/Dockerfile.centos8
@@ -38,6 +38,7 @@ RUN dnf distro-sync -y --nodocs && \
         make \
         nc \
         openssl-devel \
+        openssl-perl \
         patch \
         pkgconfig \
         procps \
@@ -53,6 +54,7 @@ RUN dnf distro-sync -y --nodocs && \
         wget \
         zlib-devel && \
     rm -rf /var/cache/dnf && \
+    c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.debian10
+++ b/package-builders/Dockerfile.debian10
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.debian11
+++ b/package-builders/Dockerfile.debian11
@@ -46,6 +46,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.debian9
+++ b/package-builders/Dockerfile.debian9
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.fedora32
+++ b/package-builders/Dockerfile.fedora32
@@ -31,6 +31,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         openssl-devel \
+        openssl-perl \
         patch \
         pkgconfig \
         procps \
@@ -44,6 +45,7 @@ RUN dnf distro-sync -y --nodocs && \
         wget \
         zlib-devel && \
     rm -rf /var/cache/dnf && \
+    c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.fedora33
+++ b/package-builders/Dockerfile.fedora33
@@ -31,6 +31,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         openssl-devel \
+        openssl-perl \
         patch \
         pkgconfig \
         procps \
@@ -44,6 +45,7 @@ RUN dnf distro-sync -y --nodocs && \
         wget \
         zlib-devel && \
     rm -rf /var/cache/dnf && \
+    c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.fedora34
+++ b/package-builders/Dockerfile.fedora34
@@ -31,6 +31,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         openssl-devel \
+        openssl-perl \
         patch \
         pkgconfig \
         procps \
@@ -44,6 +45,7 @@ RUN dnf distro-sync -y --nodocs && \
         wget \
         zlib-devel && \
     rm -rf /var/cache/dnf && \
+    c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.opensuse15.2
+++ b/package-builders/Dockerfile.opensuse15.2
@@ -43,6 +43,7 @@ RUN zypper update -y && \
                       wget && \
     zypper clean && \
     rm -rf /var/cache/zypp/*/* && \
+    c_rehash && \
     mkdir -p /usr/src/packages/BUILD /usr/src/packages/RPMS /usr/src/packages/SOURCES /usr/src/packages/SPECS /usr/src/packages/SRPMS
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.ubuntu16.04
+++ b/package-builders/Dockerfile.ubuntu16.04
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu18.04
+++ b/package-builders/Dockerfile.ubuntu18.04
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.ubuntu20.04
+++ b/package-builders/Dockerfile.ubuntu20.04
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.ubuntu20.10
+++ b/package-builders/Dockerfile.ubuntu20.10
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh

--- a/package-builders/Dockerfile.ubuntu21.04
+++ b/package-builders/Dockerfile.ubuntu21.04
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        wget \
                        zlib1g-dev && \
     apt-get clean && \
+    c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
 COPY package-builders/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
It seems to not be run automatically in some cases, which causes the package builds to eventually fail.