### PR TITLE
Add 32-bit ARM Fedora 34 package builder image.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -45,7 +45,7 @@ jobs:
           - os: fedora33
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: fedora34
-            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: opensuse15.2
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
           - os: ubuntu16.04


### PR DESCRIPTION
It was originally not included due to the upstream Docker image not supporting 32-bit ARM.