### PR TITLE
Fix IPMI dependency in Debian 11 package builder.

### DIFF
--- a/package-builders/Dockerfile.debian11
+++ b/package-builders/Dockerfile.debian11
@@ -27,6 +27,7 @@ RUN apt-get update && \
                        libcups2-dev \
                        libdistro-info-perl \
                        libelf-dev \
+                       libfreeipmi-dev \
                        libipmimonitoring-dev \
                        libjson-c-dev \
                        libjudy-dev \


### PR DESCRIPTION
We need an additional dependency on Debian 11 to get the FreeIPMI plugin to build correctly.