### PR TITLE
Fix error in Ubuntu 16.04 package builder.

### DIFF
--- a/package-builders/Dockerfile.ubuntu16.04
+++ b/package-builders/Dockerfile.ubuntu16.04
@@ -50,7 +50,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-COPY package-builders/entrypoint.sh /build.sh
+COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
We should be copying the entrypoint script to it’s own file.