### PR TITLE
Actually return a non-zero exit on a package build failure.

### DIFF
--- a/package-builders/entrypoint.sh
+++ b/package-builders/entrypoint.sh
@@ -5,6 +5,8 @@ fail() {
   if [ -t 1 ]; then
     printf "Dropping into a shell..."
     exec /bin/sh
+  else
+    exit 1
   fi
 }
 


### PR DESCRIPTION
Instead of exiting with a 0 exit status and then failing on a later step due to a lack of properly build packages.