### PR TITLE
Properly handle bogus pkg-config file on Debian systems.

### DIFF
--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -9,10 +9,13 @@ if [ -z "${BUILD_DATE}" ]; then
 fi
 
 # If libipmimonitoring.pc is borked, fix it.
-if [ -e "/usr/lib/$(uname -m)-linux-gnu/pkgconfig/libipmimonitoring.pc/libipmimonitoring.pc" ] ; then
-  mv "/usr/lib/$(uname -m)-linux-gnu/pkgconfig/libipmimonitoring.pc" tmp/libipmimonitoring
-  mv tmp/libipmimonitoring/libipmimonitoring.pc "/usr/lib/$(uname -m)-linux-gnu/pkgconfig"
-fi
+for path in $(pkg-config --variable pc_path pkg-config | tr ':' ' '); do
+  if [ -e "${path}/libipmimonitoring.pc/libipmimonitoring.pc" ] ; then
+    mv "${path}/libipmimonitoring.pc" tmp/libipmimonitoring
+    mv tmp/libipmimonitoring/libipmimonitoring.pc "${path}"
+    break
+  fi
+done
 
 # Run the builds in an isolated source directory.
 # This removes the need for cleanup, and ensures anything the build does


### PR DESCRIPTION
Instead of assuming the CPU architecture will match the system architecture, just check through all the configured pkg-config paths for the known bogus file and fix it if found.

This fixes the 32-bit x86 native package builds for Debian 11.