### PR TITLE
Add Ubuntu 21.10 package builder images.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -27,6 +27,7 @@ jobs:
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
+          - ubuntu21.10
         include:
           - os: centos7
             arches: linux/amd64 # Unable to provide alternate arches due to our dependence on OKay.
@@ -51,6 +52,8 @@ jobs:
           - os: ubuntu20.04
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu21.04
+            arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
+          - os: ubuntu21.10
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
       max-parallel: 8
     runs-on: ubuntu-latest

--- a/package-builders/Dockerfile.ubuntu21.04
+++ b/package-builders/Dockerfile.ubuntu21.04
@@ -18,7 +18,6 @@ RUN apt-get update && \
                        curl \
                        dh-autoreconf \
                        dh-make \
-                       dh-systemd \
                        systemd \
                        dpkg-dev \
                        g++ \

--- a/package-builders/Dockerfile.ubuntu21.10
+++ b/package-builders/Dockerfile.ubuntu21.10
@@ -1,0 +1,57 @@
+FROM ubuntu:21.10
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends autoconf \
+                       autoconf-archive \
+                       autogen \
+                       automake \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       dh-autoreconf \
+                       dh-make \
+                       dh-systemd \
+                       systemd \
+                       dpkg-dev \
+                       g++ \
+                       gcc \
+                       git-core \
+                       git-buildpackage \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libnetfilter-acct-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       libtool \
+                       libuv1-dev \
+                       make \
+                       pkg-config \
+                       protobuf-compiler \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/debian-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu21.10
+++ b/package-builders/Dockerfile.ubuntu21.10
@@ -18,7 +18,6 @@ RUN apt-get update && \
                        curl \
                        dh-autoreconf \
                        dh-make \
-                       dh-systemd \
                        systemd \
                        dpkg-dev \
                        g++ \


### PR DESCRIPTION
Expected release of Ubuntu 21.10 is 2021-10-14.