### PR TITLE
Add Oracle Linux 8 package builder.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -29,6 +29,7 @@ jobs:
           - fedora35
           - opensuse15.2
           - opensuse15.3
+          - oraclelinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -64,6 +65,7 @@ jobs:
           - fedora35
           - opensuse15.2
           - opensuse15.3
+          - oraclelinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -82,6 +84,8 @@ jobs:
           - {os: opensuse15.2, platform: linux/arm/v7}
           - {os: opensuse15.3, platform: linux/i386}
           - {os: opensuse15.3, platform: linux/arm/v7}
+          - {os: oraclelinux8, platform: linux/i386}
+          - {os: oraclelinux8, platform: linux/arm/v7}
           - {os: ubuntu20.04, platform: linux/i386}
           - {os: ubuntu21.04, platform: linux/i386}
           - {os: ubuntu21.10, platform: linux/i386}
@@ -121,6 +125,7 @@ jobs:
           - fedora35
           - opensuse15.2
           - opensuse15.3
+          - oraclelinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -146,6 +151,8 @@ jobs:
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
           - os: opensuse15.3
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
+          - os: oraclelinux8
+            arches: linux/amd64,linux/arm64/v8 # No other platforms
           - os: ubuntu18.04
             arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu20.04

--- a/package-builders/Dockerfile.oraclelinux8
+++ b/package-builders/Dockerfile.oraclelinux8
@@ -1,0 +1,58 @@
+FROM oraclelinux:8
+
+ENV VERSION=$VERSION
+
+COPY package-builders/oraclelinux8-codeready.repo /etc/yum.repos.d/codeready_builder.repo
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git \
+        json-c-devel \
+        libmnl-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        lm_sensors \
+        lz4-devel \
+        make \
+        nc \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-pyyaml \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/oraclelinux8-codeready.repo
+++ b/package-builders/oraclelinux8-codeready.repo
@@ -1,0 +1,6 @@
+[ol8_codeready_builder]
+name=Oracle Linux $releasever CodeReady Builder ($basearch)
+baseurl=http://yum.oracle.com/repo/OracleLinux/OL8/codeready/builder/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1


### PR DESCRIPTION
This is only adding OL8 as we cannot support OL6 (for the same reasons we can’t build for CentOS 6) and OL7 has a number of ridiculous complexities that are probably not worth working around.

We have to use a pre-generated repo config file for the OL8 CodeReady repo as there is no way other than manually creating the file to enable it for OL8.