### PR TITLE
Add Rocky Linux 8 package builder image.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -30,6 +30,7 @@ jobs:
           - opensuse15.2
           - opensuse15.3
           - oraclelinux8
+          - rockylinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -66,6 +67,7 @@ jobs:
           - opensuse15.2
           - opensuse15.3
           - oraclelinux8
+          - rockylinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -86,6 +88,8 @@ jobs:
           - {os: opensuse15.3, platform: linux/arm/v7}
           - {os: oraclelinux8, platform: linux/i386}
           - {os: oraclelinux8, platform: linux/arm/v7}
+          - {os: rockylinux8, platform: linux/i386}
+          - {os: rockylinux8, platform: linux/arm/v7}
           - {os: ubuntu20.04, platform: linux/i386}
           - {os: ubuntu21.04, platform: linux/i386}
           - {os: ubuntu21.10, platform: linux/i386}
@@ -126,6 +130,7 @@ jobs:
           - opensuse15.2
           - opensuse15.3
           - oraclelinux8
+          - rockylinux8
           - ubuntu18.04
           - ubuntu20.04
           - ubuntu21.04
@@ -152,6 +157,8 @@ jobs:
           - os: opensuse15.3
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
           - os: oraclelinux8
+            arches: linux/amd64,linux/arm64/v8 # No other platforms
+          - os: rockylinux8
             arches: linux/amd64,linux/arm64/v8 # No other platforms
           - os: ubuntu18.04
             arches: linux/amd64,linux/i386,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x

--- a/package-builders/Dockerfile.rockylinux8
+++ b/package-builders/Dockerfile.rockylinux8
@@ -1,0 +1,61 @@
+FROM rockylinux/rockylinux:8
+
+ENV VERSION=$VERSION
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf install -y --nodocs 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled powertools && \
+    dnf clean packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git \
+        json-c-devel \
+        libmnl-devel \
+        # FIXME: broken / Missing
+        # XXX: Can't (currently) find a CentOS 8 package for this :/
+        #libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        lm_sensors \
+        lz4-devel \
+        make \
+        nc \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-pyyaml \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]


### PR DESCRIPTION
Long-term this will replace our CentOS 8 package builder image.