### PR TITLE
Handle package versioning correctly.

### DIFF
--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -24,6 +24,7 @@ done
 # This removes the need for cleanup, and ensures anything the build does
 # doesn't muck with the user's sources.
 cp -a /netdata /usr/src || exit 1
+rm -rf /usr/src/netdata/.git || exit 1
 cd /usr/src/netdata || exit 1
 
 cp -a contrib/debian debian || exit 1

--- a/package-builders/fedora-build.sh
+++ b/package-builders/fedora-build.sh
@@ -5,6 +5,7 @@ cp /netdata/netdata.spec.in /root/rpmbuild/SPECS/netdata.spec || exit 1
 pkg_version="$(echo "${VERSION}" | tr - .)"
 
 cp -a /netdata "/root/rpmbuild/SOURCES/netdata-${pkg_version}" || exit 1
+rm -rf "/root/rpmbuild/SOURCES/netdata-${pkg_version}/.git" || exit 1
 
 # These next few steps prep the spec file for building with local sources.
 # Without this, we would have to create a tarball of the local sources

--- a/package-builders/suse-build.sh
+++ b/package-builders/suse-build.sh
@@ -5,6 +5,7 @@ cp /netdata/netdata.spec.in /usr/src/packages/SPECS/netdata.spec || exit 1
 pkg_version="$(echo "${VERSION}" | tr - .)"
 
 cp -a /netdata "/usr/src/packages/SOURCES/netdata-${pkg_version}" || exit 1
+rm -rf "/usr/src/packages/SOURCES/netdata-${pkg_version}/.git" || exit 1
 
 # These next few steps prep the spec file for building with local sources.
 # Without this, we would have to create a tarball of the local sources


### PR DESCRIPTION
This removes the `.git` directory from the source directory we are using to perform package builds before actually building the packages, ensuring they utilize the `packaging/version` file to determine the version number instead of running `git describe`.

Fixes: https://github.com/netdata/netdata/issues/12333