### PR TITLE
Assorted cleanup of our Docker images.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,32 +11,33 @@
 FROM alpine:3.15 as builder
 
 # Install some prerequisites
-RUN apk --no-cache add curl \
+RUN apk --no-cache add apcupsd \
+                       curl \
                        fping \
+                       iproute2 \
                        jq \
                        json-c \
+                       libgcrypt \
                        libmnl \
                        libuuid \
-                       lm_sensors \
-                       netcat-openbsd \
-                       nodejs \
-                       util-linux \
-                       zlib \
                        libuv \
-                       openssl \
+                       libvirt-daemon \
+                       lm-sensors \
                        lz4 \
                        lz4-libs \
-                       libvirt-daemon \
-                       libgcrypt \
-                       iproute2 \
-                       shadow \
-                       msmtp \
-                       postgresql-client \
                        mongo-c-driver \
-                       python3 \
-                       py3-pip \
+                       msmtp \
+                       netcat-openbsd \
+                       nodejs \
+                       openssl \
+                       postgresql-client \
                        protobuf \
-                       snappy
+                       py3-pip \
+                       python3 \
+                       shadow \
+                       snappy \
+                       util-linux \
+                       zlib
 
 # Add nut dependency from alpine-edge
-RUN apk --no-cache add nut lm-sensors --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,32 +12,31 @@ RUN apk --no-cache add alpine-sdk \
                        automake \
                        bash \
                        build-base \
+                       cmake \
                        curl \
                        jq \
                        json-c-dev \
+                       libgcrypt-dev \
                        libmnl-dev \
                        libtool \
                        libuuid \
+                       libuv-dev \
                        lm_sensors \
+                       lz4-dev \
+                       mariadb-dev \
+                       mongo-c-driver-dev \
+                       musl-dev \
                        netcat-openbsd \
-                       nodejs \
+                       openssl-dev \
                        pkgconfig \
+                       postgresql-dev \
+                       protobuf-dev \
                        py3-pip \
                        python3 \
                        python3-dev \
+                       snappy-dev \
                        util-linux-dev \
-                       zlib-dev \
-                       libuv-dev \
-                       lz4-dev \
-                       openssl-dev \
-                       libgcrypt-dev \
-                       mariadb-dev \
-                       cmake \
-                       musl-dev \
-                       postgresql-dev \
-                       mongo-c-driver-dev \
-                       protobuf-dev \
-                       snappy-dev
+                       zlib-dev
 
 # Add Python dependencies from PyPi using `pip`
 COPY builder/requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
* Remove NodeJS from the builder image, as it’s not actually used at build time (it will be removed from the base image at a later date, when we finally switch to Go for SNMP data collection support).
* Sort the dependency lists so that they are easier to maintain long-term.
* Add apcupsd to the base image, to make the APC UPS data collector work properly.
* Use lm-sensors from the regular repos instead of the edge repos, as it’s the same version there now.

Fixes: netdata/netdata#12346