### PR TITLE
Change source of NUT package in base image.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -39,4 +39,4 @@ RUN apk --no-cache add apcupsd \
                        zlib
 
 # Add nut dependency from alpine-edge
-RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add nut --repository http://dl-cdn.alpinelinux.org/alpine/edge/community --repository http://dl-cdn.alpinelinux.org/alpine/edge/main


### PR DESCRIPTION
It’s made it into the community repo in Alpine Edge, so pull from there instead of trying to pull from testing.

This fixes a build error in the base image build.