### PR TITLE
Bump Alpine helper images to 3.16

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,7 +8,7 @@
 
 # This image is used to speed up build process for official netdata images.
 
-FROM alpine:3.15 as builder
+FROM alpine:3.16 as builder
 
 # Install some prerequisites
 RUN apk --no-cache add apcupsd \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -4,7 +4,7 @@
 
 # This image is used to speed up build process for official netdata images.
 
-FROM alpine:3.15 as builder
+FROM alpine:3.16 as builder
 
 # Install prerequisites
 RUN apk --no-cache add alpine-sdk \

--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk add --no-cache \
     alpine-sdk \


### PR DESCRIPTION
This will update our Docker images and static builds to use Alpine 3.16 as a base.