### PR TITLE
remove psycopg2 from requirements

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,3 +1,2 @@
 pymongo
 mysqlclient
-psycopg2

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,2 +1,1 @@
 pymongo
-psycopg2


### PR DESCRIPTION
Should be merged after v1.36.0 is out.

---

Python Postgres collector is [expected to be removed](https://github.com/netdata/netdata/pull/13503) after the v1.36.0 release. 