### PR TITLE
remove fping

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -41,5 +41,4 @@ RUN apk --no-cache add apcupsd \
 RUN apk --no-cache \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
         --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        add nut \
-            fping
+        add nut


### PR DESCRIPTION
> **Warning**: should be merged a bit later after we ensure there won't be v1.37.1

On the other hand, we can get it back if/when we need (I hope never) v1.37.1?

---

In accordance with [v1.37.0 deprecation notice](https://github.com/netdata/netdata/releases/tag/v1.37.0#v1370-deprecation).

PR in netdata/netdata is https://github.com/netdata/netdata/pull/14073.