### PR TITLE
Update base image

### DIFF
--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
     jq \
     libelf-static \
     libmnl-dev \
-    libnetfilter_acct-dev \
+    libmnl-static \
     libtool \
     libuv-dev \
     libuv-static \


### PR DESCRIPTION
We need the static builds of `libmnl` for the `libnetfilter_acct`
Signed-off-by: Tasos Katsoulas <tasos@netdata.cloud>