### PR TITLE
cleanup parorama (fedora 35)

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -139,7 +139,6 @@ jobs:
           - debian10
           - debian11
           - debian12
-          - fedora35
           - fedora36
           - fedora37
           - opensuse_tumbleweed


### PR DESCRIPTION
remove an oversight from our ci