### PR TITLE
Add ncurses to our base Docker image so tput is available.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -33,6 +33,7 @@ RUN apk --no-cache add apcupsd \
                        lz4-libs \
                        mongo-c-driver \
                        msmtp \
+                       ncurses \
                        netcat-openbsd \
                        nut \
                        openssl \


### PR DESCRIPTION
We use `tput` in the `edit-config` script, so we should make sure it’s available in our Docker images, which means we need to install `ncurses`.