### PR TITLE
Skip build checks when publishing images.

### DIFF
--- a/.github/workflows/base-builder.yml
+++ b/.github/workflows/base-builder.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-check:
     name: Build Check
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,7 +69,6 @@ jobs:
   publish:
     name: Publish Images
     if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
-    needs: build-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-check:
     name: Build Check
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -138,7 +138,6 @@ jobs:
   publish:
     name: Publish Images
     if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
-    needs: build-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/static-builder.yml
+++ b/.github/workflows/static-builder.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-check:
     name: Build Check
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -60,7 +60,6 @@ jobs:
   publish:
     name: Publish Images
     if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
-    needs: build-check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The current structure of the CI workflows for building the Docker images in this repo is directly based on the structure of the Docker build workflow in https://github.com/netdata/netdata.  However, this repo doesn’t need to do any runtime checks prior to publishing the images, so the build check jobs largely just waste time when the workflow is running to publish the images.

Given this, it makes sense to just decouple the build-check jobs from the publishing jobs.

This results in a significant improvement in the time it takes to publish the images after a PR is merged, as well as reducing the overall impact on other CI.