### PR TITLE
add curl static to static-builder image

### DIFF
--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
     bison \
     cmake \
     curl \
+    curl-static \
     elfutils-dev \
     flex \
     gcc \


### PR DESCRIPTION
want this for sentry, but we can also may get rid of this https://github.com/netdata/netdata/blob/master/packaging/makeself/jobs/50-curl-7.87.0.install.sh

cc @Ferroin 