### PR TITLE
Add ZSTD headers and libraries to builder images.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -45,7 +45,8 @@ RUN apk --no-cache add apcupsd \
                        shadow \
                        snappy \
                        util-linux \
-                       zlib && \
+                       zlib \
+                       zstd-libs && \
     if [ "$(uname -m)" != "ppc64le" ]; then \
         apk --no-cache add freeipmi freeipmi-libs || exit 1 ; \
     fi

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -46,7 +46,8 @@ RUN apk --no-cache add alpine-sdk \
                        python3-dev \
                        snappy-dev \
                        util-linux-dev \
-                       zlib-dev && \
+                       zlib-dev \
+                       zstd-dev && \
     mkdir -p /deps/etc && \
     if [ "$(uname -m)" != "ppc64le" ]; then \
         apk --no-cache add freeipmi-dev || exit 1 ; \

--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -45,4 +45,6 @@ RUN apk add --no-cache \
     wget \
     xz \
     zlib-dev \
-    zlib-static
+    zlib-static \
+    zstd-dev \
+    zstd-static


### PR DESCRIPTION
They apparently are needed by the build process.