### PR TITLE
Make openSUSE package builder image builds more robust.

### DIFF
--- a/package-builders/Dockerfile.opensuse15.4
+++ b/package-builders/Dockerfile.opensuse15.4
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=0.1
 
 RUN zypper update -y && \
-    zypper install -y --allow-downgrading \
+    zypper install -y --allow-downgrade \
                       autoconf \
                       autoconf-archive \
                       autogen \

--- a/package-builders/Dockerfile.opensuse15.4
+++ b/package-builders/Dockerfile.opensuse15.4
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=0.1
 
 RUN zypper update -y && \
-    zypper install -y autoconf \
+    zypper install -y --allow-downgrading \
+                      autoconf \
                       autoconf-archive \
                       autogen \
                       automake \

--- a/package-builders/Dockerfile.opensuse15.5
+++ b/package-builders/Dockerfile.opensuse15.5
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=0.1
 
 RUN zypper update -y && \
-    zypper install -y --allow-downgrading \
+    zypper install -y --allow-downgrade \
                       autoconf \
                       autoconf-archive \
                       autogen \

--- a/package-builders/Dockerfile.opensuse15.5
+++ b/package-builders/Dockerfile.opensuse15.5
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=0.1
 
 RUN zypper update -y && \
-    zypper install -y autoconf \
+    zypper install -y --allow-downgrading \
+                      autoconf \
                       autoconf-archive \
                       autogen \
                       automake \

--- a/package-builders/Dockerfile.opensusetumbleweed
+++ b/package-builders/Dockerfile.opensusetumbleweed
@@ -9,7 +9,8 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=$VERSION
 
 RUN zypper update -y && \
-    zypper install -y autoconf \
+    zypper install -y --allow-downgrading \
+                      autoconf \
                       autoconf-archive \
                       autogen \
                       automake \

--- a/package-builders/Dockerfile.opensusetumbleweed
+++ b/package-builders/Dockerfile.opensusetumbleweed
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.vendor="Netdata Inc."
 ENV VERSION=$VERSION
 
 RUN zypper update -y && \
-    zypper install -y --allow-downgrading \
+    zypper install -y --allow-downgrade \
                       autoconf \
                       autoconf-archive \
                       autogen \


### PR DESCRIPTION
This should fix the failures on 15.4.