### PR TITLE
added additional linting exceptions for warnings of the form:

### DIFF
--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -4,5 +4,7 @@
 # see https://github.com/hadolint/hadolint#rules for a list of available rules.
 ---
 ignored:
-  - DL3041
   - DL3008
+  - DL3033
+  - DL3037
+  - DL3041


### PR DESCRIPTION
Added additional linting exceptions for warnings of the form:
"Specify version with yum install -y <package>-<version>",
but for additional package managers.
Sorted rules numerically to prevent OCD.
Added extra line EOF because linting lint files is a thing :)
Every little helps :-D