### PR TITLE
Fixed double libcurl in rpm packages

### DIFF
--- a/package-builders/Dockerfile.almalinux8
+++ b/package-builders/Dockerfile.almalinux8
@@ -34,7 +34,6 @@ RUN dnf distro-sync -y --nodocs && \
         golang \
         json-c-devel \
         libatomic \
-        libcurl-devel \
         libmnl-devel \
         # FIXME: broken / Missing
         # XXX: Can't (currently) find a CentOS 8 package for this :/

--- a/package-builders/Dockerfile.oraclelinux8
+++ b/package-builders/Dockerfile.oraclelinux8
@@ -22,6 +22,7 @@ RUN dnf distro-sync -y --nodocs && \
         cmake \
         cups-devel \
         curl \
+        libcurl-devel \
         diffutils \
         elfutils-libelf-devel \
         findutils \
@@ -32,7 +33,6 @@ RUN dnf distro-sync -y --nodocs && \
         git \
         golang \
         json-c-devel \
-        libcurl-devel \
         libyaml-devel \
         libatomic \
         libmnl-devel \


### PR DESCRIPTION
```python
√ helper-images % ack curl package-builders/Dockerfile.almalinux8
        curl \
        libcurl-devel \
```