### PR TITLE
Switch to using Debian as a base for our Docker images.

### DIFF
--- a/.github/data/matrices.yaml
+++ b/.github/data/matrices.yaml
@@ -26,6 +26,7 @@ base:
     - builder
   revisions:
     - v1
+    - v2
   platforms:
     - linux/amd64
     - linux/386

--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -19,7 +19,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN chown _apt:root /var/cache/apt /var/lib/apt && \
     apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends apt-utils && \
     apt-get install -y --no-install-recommends \
+                    ca-certificates \
                     curl \
                     fping \
                     iproute2 \
@@ -44,6 +46,7 @@ RUN chown _apt:root /var/cache/apt /var/lib/apt && \
                     ncurses-base \
                     netcat-openbsd \
                     openssl \
+                    procps \
                     python3 \
                     zlib1g && \
     if [ "$(uname -m)" != "ppc64le" ]; then \

--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -38,7 +38,7 @@ RUN chown _apt:root /var/cache/apt /var/lib/apt && \
                     libsystemd0 \
                     libuuid1 \
                     libuv1 \
-                    libvirt0 \
+                    libvirt-clients \
                     libyaml-0-2 \
                     libzstd1 \
                     lm-sensors \

--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -1,0 +1,52 @@
+# This image is used to speed up build process for official netdata images.
+#
+# Copyright: 2019 and later Netdata Incorporated
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
+# Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
+
+FROM debian:12 as builder
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Agent Docker Base Image"
+LABEL org.opencontainers.image.description="Base image for official Netdata Agent Docker images."
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN chown _apt:root /var/cache/apt /var/lib/apt && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                    curl \
+                    fping \
+                    iproute2 \
+                    jq \
+                    libgcrypt20 \
+                    libjson-c5 \
+                    liblz4-1 \
+                    libmariadb3 \
+                    libmnl0 \
+                    libmongoc-1.0-0 \
+                    libprotobuf32 \
+                    libsnappy1v5 \
+                    libssl3 \
+                    libsystemd0 \
+                    libuuid1 \
+                    libuv1 \
+                    libvirt0 \
+                    libyaml-0-2 \
+                    libzstd1 \
+                    lm-sensors \
+                    msmtp \
+                    ncurses-base \
+                    netcat-openbsd \
+                    openssl \
+                    python3 \
+                    zlib1g && \
+    if [ "$(uname -m)" != "ppc64le" ]; then \
+        apt-get install -y --no-install-recommends freeipmi libipmimonitoring6 || exit 1 ; \
+    fi && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -1,0 +1,59 @@
+# This image is used to speed up build process for official netdata images.
+#
+# Copyright: 2019 and later Netdata Incorporated
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
+# Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
+
+FROM debian:12 as builder
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Agent Docker Builder Image"
+LABEL org.opencontainers.image.description="Builder image for official Netdata Agent Docker images."
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN chown _apt:root /var/cache/apt /var/lib/apt && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                    autoconf \
+                    autoconf-archive \
+                    automake \
+                    bison \
+                    build-essential \
+                    cmake \
+                    curl \
+                    flex \
+                    git \
+                    jq \
+                    libgcrypt-dev \
+                    libjson-c-dev \
+                    liblz4-dev \
+                    libmariadb-dev \
+                    libmnl-dev \
+                    libmongoc-dev \
+                    libprotobuf-dev \
+                    libsnappy-dev \
+                    libssl-dev \
+                    libsystemd-dev \
+                    libtool \
+                    libuv1-dev \
+                    libvirt-dev \
+                    libyaml-dev \
+                    libzstd-dev \
+                    openssl \
+                    pkgconf \
+                    protobuf-compiler \
+                    python3 \
+                    python3-dev \
+                    uuid-dev \
+                    zlib1g-dev && \
+    if [ "$(uname -m)" != "ppc64le" ]; then \
+        apt-get install -y --no-install-recommends libfreeipmi-dev libipmimonitoring-dev || exit 1 ; \
+    fi && \
+    mkdir -p /deps/etc && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -44,7 +44,6 @@ RUN chown _apt:root /var/cache/apt /var/lib/apt && \
                     libsystemd-dev \
                     libtool \
                     libuv1-dev \
-                    libvirt-dev \
                     libyaml-dev \
                     libzstd-dev \
                     openssl \

--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -19,12 +19,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN chown _apt:root /var/cache/apt /var/lib/apt && \
     apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends apt-utils && \
     apt-get install -y --no-install-recommends \
                     autoconf \
                     autoconf-archive \
                     automake \
                     bison \
                     build-essential \
+                    ca-certificates \
                     cmake \
                     curl \
                     flex \


### PR DESCRIPTION
Rationale and testing procedure can be found in https://github.com/netdata/netdata/pull/15823.

This should not be merged until shortly before https://github.com/netdata/netdata/pull/15823 is scheduled to be merged, as it will break the existing Docker image build process.

Includes some cleanup in the builder image to drop packages that we really do not need there.