### PR TITLE
Switch to Rocky Linux as base for EL package builders.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - almalinux8
-          - almalinux9
           - amazonlinux2
           - amazonlinux2023
           - centos-stream8
@@ -36,6 +34,8 @@ jobs:
           - opensuse15.5
           - oraclelinux8
           - oraclelinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu23.04
@@ -62,23 +62,23 @@ jobs:
     strategy:
       matrix:
         os:
-          - almalinux8
-          - almalinux9
           - amazonlinux2
           - amazonlinux2023
+          - centos7
           - centos-stream8
           - centos-stream9
-          - centos7
           - debian10
           - debian11
           - debian12
           - fedora37
           - fedora38
-          - opensusetumbleweed
           - opensuse15.4
           - opensuse15.5
+          - opensusetumbleweed
           - oraclelinux8
           - oraclelinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu23.04
@@ -87,35 +87,35 @@ jobs:
           - linux/arm/v7
           - linux/arm64/v8
         exclude: # don’t try to run these specific combinations
-          - {os: almalinux8, platform: linux/i386}
-          - {os: almalinux8, platform: linux/arm/v7}
-          - {os: almalinux9, platform: linux/i386}
-          - {os: almalinux9, platform: linux/arm/v7}
-          - {os: amazonlinux2, platform: linux/i386}
-          - {os: amazonlinux2, platform: linux/arm/v7}
-          - {os: amazonlinux2023, platform: linux/i386}
           - {os: amazonlinux2023, platform: linux/arm/v7}
-          - {os: centos-stream8, platform: linux/i386}
-          - {os: centos-stream8, platform: linux/arm/v7}
-          - {os: centos-stream9, platform: linux/i386}
-          - {os: centos-stream9, platform: linux/arm/v7}
-          - {os: centos7, platform: linux/i386}
-          - {os: centos7, platform: linux/arm/v7}
+          - {os: amazonlinux2023, platform: linux/i386}
+          - {os: amazonlinux2, platform: linux/arm/v7}
+          - {os: amazonlinux2, platform: linux/i386}
           - {os: centos7, platform: linux/arm64/v8}
-          - {os: fedora37, platform: linux/i386}
+          - {os: centos7, platform: linux/arm/v7}
+          - {os: centos7, platform: linux/i386}
+          - {os: centos-stream8, platform: linux/arm/v7}
+          - {os: centos-stream8, platform: linux/i386}
+          - {os: centos-stream9, platform: linux/arm/v7}
+          - {os: centos-stream9, platform: linux/i386}
           - {os: fedora37, platform: linux/arm/v7}
-          - {os: fedora38, platform: linux/i386}
+          - {os: fedora37, platform: linux/i386}
           - {os: fedora38, platform: linux/arm/v7}
-          - {os: opensuse15.4, platform: linux/i386}
+          - {os: fedora38, platform: linux/i386}
           - {os: opensuse15.4, platform: linux/arm/v7}
-          - {os: opensuse15.5, platform: linux/i386}
+          - {os: opensuse15.4, platform: linux/i386}
           - {os: opensuse15.5, platform: linux/arm/v7}
-          - {os: opensusetumbleweed, platform: linux/i386}
+          - {os: opensuse15.5, platform: linux/i386}
           - {os: opensusetumbleweed, platform: linux/arm/v7}
-          - {os: oraclelinux8, platform: linux/i386}
+          - {os: opensusetumbleweed, platform: linux/i386}
           - {os: oraclelinux8, platform: linux/arm/v7}
-          - {os: oraclelinux9, platform: linux/i386}
+          - {os: oraclelinux8, platform: linux/i386}
           - {os: oraclelinux9, platform: linux/arm/v7}
+          - {os: oraclelinux9, platform: linux/i386}
+          - {os: rockylinux8, platform: linux/arm/v7}
+          - {os: rockylinux8, platform: linux/i386}
+          - {os: rockylinux9, platform: linux/arm/v7}
+          - {os: rockylinux9, platform: linux/i386}
           - {os: ubuntu20.04, platform: linux/i386}
           - {os: ubuntu22.04, platform: linux/i386}
           - {os: ubuntu23.04, platform: linux/i386}
@@ -145,31 +145,27 @@ jobs:
     strategy:
       matrix:
         os:
-          - almalinux8
-          - almalinux9
           - amazonlinux2
           - amazonlinux2023
+          - centos7
           - centos-stream8
           - centos-stream9
-          - centos7
           - debian10
           - debian11
           - debian12
           - fedora37
           - fedora38
-          - opensusetumbleweed
           - opensuse15.4
           - opensuse15.5
+          - opensusetumbleweed
           - oraclelinux8
           - oraclelinux9
+          - rockylinux8
+          - rockylinux9
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu23.04
         include:
-          - os: almalinux8
-            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le
-          - os: almalinux9
-            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: amazonlinux2
             arches: linux/amd64,linux/arm64/v8 # No other platforms
           - os: amazonlinux2023
@@ -200,6 +196,10 @@ jobs:
             arches: linux/amd64,linux/arm64/v8 # No other platforms
           - os: oraclelinux9
             arches: linux/amd64,linux/arm64/v8 # No other platforms
+          - os: rockylinux8
+            arches: linux/amd64,linux/arm64/v8 # No other platforms
+          - os: rockylinux9
+            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu20.04
             arches: linux/amd64,linux/arm/v7,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: ubuntu22.04

--- a/package-builders/Dockerfile.rockylinux8
+++ b/package-builders/Dockerfile.rockylinux8
@@ -1,9 +1,9 @@
-FROM almalinux:8
+FROM rockylinux:8
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
-LABEL org.opencontainers.image.title="Netdata Package Builder for Alma Linux 8"
-LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Alma Linux 8"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Rocky Linux 8"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Rocky Linux 8"
 LABEL org.opencontainers.image.vendor="Netdata Inc."
 
 ENV VERSION=$VERSION

--- a/package-builders/Dockerfile.rockylinux9
+++ b/package-builders/Dockerfile.rockylinux9
@@ -1,9 +1,9 @@
-FROM almalinux:9
+FROM rockylinux:9
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
-LABEL org.opencontainers.image.title="Netdata Package Builder for Alma Linux 9"
-LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Alma Linux 9"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Rocky Linux 9"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Rocky Linux 9"
 LABEL org.opencontainers.image.vendor="Netdata Inc."
 
 ENV VERSION=$VERSION


### PR DESCRIPTION
Alma Linux has formally announced they are no longer trying for 1:1 compatibility with RHEL, which makes them a less than ideal choice for us to use as a build platform for our native packages. We still can’t use the RHEL universal base images as a base because of RH’s absurdist views on the usability of their platform, so Rocky Linux is our next best choice.

Once this is merged there will be an associated PR in https://github.com/netdata/netdata/ to move the CI there to use these new images.