### PR TITLE
Fix broken openSUSE package-builder images.

### DIFF
--- a/package-builders/Dockerfile.opensuse15.4
+++ b/package-builders/Dockerfile.opensuse15.4
@@ -39,13 +39,13 @@ RUN zypper update -y && \
                       libnetfilter_acct1 \
                       libnetfilter_acct-devel \
                       libopenssl-devel \
+                      libprotobuf-c-devel \
                       libtool \
                       libuv-devel \
                       libuuid-devel \
                       make \
                       patch \
                       pkg-config \
-                      protobuf-c \
                       protobuf-devel \
                       rpm-build \
                       rpm-devel \

--- a/package-builders/Dockerfile.opensuse15.5
+++ b/package-builders/Dockerfile.opensuse15.5
@@ -39,13 +39,13 @@ RUN zypper update -y && \
                       libnetfilter_acct1 \
                       libnetfilter_acct-devel \
                       libopenssl-devel \
+                      libprotobuf-c-devel \
                       libtool \
                       libuv-devel \
                       libuuid-devel \
                       make \
                       patch \
                       pkg-config \
-                      protobuf-c \
                       protobuf-devel \
                       rpm-build \
                       rpm-devel \


### PR DESCRIPTION
The actual issue is upstream, but this should work around it.