### PR TITLE
Add Ninja build system to builder images.

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -33,10 +33,12 @@ RUN apk --no-cache add alpine-sdk \
                        libuv-dev \
                        lm_sensors \
                        lz4-dev \
+                       make \
                        mariadb-dev \
                        mongo-c-driver-dev \
                        musl-dev \
                        musl-fts-dev \
+                       ninja \
                        netcat-openbsd \
                        openssl-dev \
                        pkgconfig \

--- a/package-builders/Dockerfile.amazonlinux2
+++ b/package-builders/Dockerfile.amazonlinux2
@@ -40,6 +40,7 @@ RUN yum update -y && \
                    lm_sensors \
                    lz4-devel \
                    make \
+                   ninja \
                    openssl-devel \
                    openssl-perl \
                    patch \

--- a/package-builders/Dockerfile.amazonlinux2023
+++ b/package-builders/Dockerfile.amazonlinux2023
@@ -42,6 +42,7 @@ RUN dnf distro-sync -y --nodocs && \
         lm_sensors \
         lz4-devel \
         make \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.centos-stream8
+++ b/package-builders/Dockerfile.centos-stream8
@@ -42,6 +42,7 @@ RUN dnf distro-sync -y --nodocs && \
         lm_sensors \
         lz4-devel \
         make \
+        ninja \
         nc \
         openssl-devel \
         openssl-perl \

--- a/package-builders/Dockerfile.centos-stream9
+++ b/package-builders/Dockerfile.centos-stream9
@@ -41,6 +41,7 @@ RUN dnf distro-sync -y --nodocs && \
         lm_sensors \
         lz4-devel \
         make \
+        ninja \
         nc \
         openssl-devel \
         openssl-perl \

--- a/package-builders/Dockerfile.centos7
+++ b/package-builders/Dockerfile.centos7
@@ -42,6 +42,7 @@ RUN yum install -y epel-release && \
                    lm_sensors \
                    lz4-devel \
                    make \
+                   ninja \
                    openssl-devel \
                    openssl-perl \
                    patch \

--- a/package-builders/Dockerfile.debian10
+++ b/package-builders/Dockerfile.debian10
@@ -53,6 +53,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/package-builders/Dockerfile.debian11
+++ b/package-builders/Dockerfile.debian11
@@ -52,6 +52,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/package-builders/Dockerfile.debian12
+++ b/package-builders/Dockerfile.debian12
@@ -46,6 +46,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/package-builders/Dockerfile.fedora37
+++ b/package-builders/Dockerfile.fedora37
@@ -41,6 +41,7 @@ RUN dnf distro-sync -y --nodocs && \
         libuv-devel \
         lz4-devel \
         make \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.fedora38
+++ b/package-builders/Dockerfile.fedora38
@@ -41,6 +41,7 @@ RUN dnf distro-sync -y --nodocs && \
         libuv-devel \
         lz4-devel \
         make \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.opensuse15.4
+++ b/package-builders/Dockerfile.opensuse15.4
@@ -44,6 +44,7 @@ RUN zypper update -y && \
                       libuv-devel \
                       libuuid-devel \
                       make \
+                      ninja \
                       patch \
                       pkg-config \
                       protobuf-devel \

--- a/package-builders/Dockerfile.opensuse15.5
+++ b/package-builders/Dockerfile.opensuse15.5
@@ -44,6 +44,7 @@ RUN zypper update -y && \
                       libuv-devel \
                       libuuid-devel \
                       make \
+                      ninja \
                       patch \
                       pkg-config \
                       protobuf-devel \

--- a/package-builders/Dockerfile.opensusetumbleweed
+++ b/package-builders/Dockerfile.opensusetumbleweed
@@ -43,6 +43,7 @@ RUN zypper update -y && \
                       libuv-devel \
                       libuuid-devel \
                       make \
+                      ninja \
                       patch \
                       pkg-config \
                       protobuf-c \

--- a/package-builders/Dockerfile.oraclelinux8
+++ b/package-builders/Dockerfile.oraclelinux8
@@ -43,6 +43,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         nc \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.oraclelinux9
+++ b/package-builders/Dockerfile.oraclelinux9
@@ -41,6 +41,7 @@ RUN dnf config-manager --set-enabled ol9_codeready_builder && \
         lz4-devel \
         make \
         nc \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.rockylinux8
+++ b/package-builders/Dockerfile.rockylinux8
@@ -46,6 +46,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         nc \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.rockylinux9
+++ b/package-builders/Dockerfile.rockylinux9
@@ -45,6 +45,7 @@ RUN dnf distro-sync -y --nodocs && \
         lz4-devel \
         make \
         nc \
+        ninja \
         openssl-devel \
         openssl-perl \
         patch \

--- a/package-builders/Dockerfile.ubuntu20.04
+++ b/package-builders/Dockerfile.ubuntu20.04
@@ -53,6 +53,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/package-builders/Dockerfile.ubuntu22.04
+++ b/package-builders/Dockerfile.ubuntu22.04
@@ -52,6 +52,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/package-builders/Dockerfile.ubuntu23.04
+++ b/package-builders/Dockerfile.ubuntu23.04
@@ -52,6 +52,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        make \
+                       ninja \
                        pkg-config \
                        protobuf-compiler \
                        systemd \

--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
     musl-fts-dev \
     ncurses \
     netcat-openbsd \
+    ninja \
     openssh \
     pkgconfig \
     protobuf-dev \


### PR DESCRIPTION
This will be used by the new CMake build infrastructure to make builds _much_ faster, thus making CI much faster.