### PR TITLE
Add Fedora 39 package builder images.

### DIFF
--- a/.github/workflows/package-builders.yml
+++ b/.github/workflows/package-builders.yml
@@ -29,6 +29,7 @@ jobs:
           - debian12
           - fedora37
           - fedora38
+          - fedora39
           - opensusetumbleweed
           - opensuse15.4
           - opensuse15.5
@@ -72,6 +73,7 @@ jobs:
           - debian12
           - fedora37
           - fedora38
+          - fedora39
           - opensuse15.4
           - opensuse15.5
           - opensusetumbleweed
@@ -102,6 +104,8 @@ jobs:
           - {os: fedora37, platform: linux/i386}
           - {os: fedora38, platform: linux/arm/v7}
           - {os: fedora38, platform: linux/i386}
+          - {os: fedora39, platform: linux/arm/v7}
+          - {os: fedora39, platform: linux/i386}
           - {os: opensuse15.4, platform: linux/arm/v7}
           - {os: opensuse15.4, platform: linux/i386}
           - {os: opensuse15.5, platform: linux/arm/v7}
@@ -155,6 +159,7 @@ jobs:
           - debian12
           - fedora37
           - fedora38
+          - fedora39
           - opensuse15.4
           - opensuse15.5
           - opensusetumbleweed
@@ -185,6 +190,8 @@ jobs:
           - os: fedora37
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: fedora38
+            arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
+          - os: fedora39
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le,linux/s390x
           - os: opensuse15.4
             arches: linux/amd64,linux/arm64/v8 # possibly linux/ppc64le

--- a/package-builders/Dockerfile.fedora39
+++ b/package-builders/Dockerfile.fedora39
@@ -1,0 +1,68 @@
+FROM fedora:39
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Fedora 38"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Fedora 38"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV VERSION=$VERSION
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        autogen \
+        automake \
+        bash \
+        bison \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        flex \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        golang \
+        json-c-devel \
+        libyaml-devel \
+        Judy-devel \
+        libatomic \
+        libcurl-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libtool \
+        libuuid-devel \
+        libuv-devel \
+        lz4-devel \
+        make \
+        ninja-build \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pkgconfig \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        systemd-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]


### PR DESCRIPTION
Betas are out as of 2023-09-20, expected release date is some time before 2023-10-31.