### PR TITLE
Add newer CMake to RHEL 7 equivalent package builders.

### DIFF
--- a/package-builders/Dockerfile.amazonlinux2
+++ b/package-builders/Dockerfile.amazonlinux2
@@ -15,7 +15,6 @@ RUN yum update -y && \
                    automake \
                    bison \
                    bison-devel \
-                   cmake \
                    cups-devel \
                    curl \
                    diffutils \
@@ -59,6 +58,16 @@ RUN yum update -y && \
     yum clean all && \
     c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+# Fetch a newer version of CMake, because the system-provided one is _ancient_.
+# It’s safe to just pull the x86_64 copy, because that's the only arch we build for on this platform.
+# The hash is hard-coded here to mitigate the risk of supply-chain attacks.
+RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-x86_64.sh \
+         https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh && \
+    echo '8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake-linux-x86_64.sh' | sha256sum -c - && \
+    chmod +x ./cmake-linux-x86_64.sh && \
+    mkdir -p /cmake && \
+    ./cmake-linux-x86_64.sh --skip-license --prefix=/cmake
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/fedora-build.sh /build.sh

--- a/package-builders/Dockerfile.centos7
+++ b/package-builders/Dockerfile.centos7
@@ -17,7 +17,6 @@ RUN yum install -y epel-release && \
                    bash \
                    bison \
                    bison-devel \
-                   cmake \
                    cups-devel \
                    curl \
                    diffutils \
@@ -61,6 +60,16 @@ RUN yum install -y epel-release && \
     yum clean all && \
     c_rehash && \
     mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+# Fetch a newer version of CMake, because the system-provided one is _ancient_.
+# It’s safe to just pull the x86_64 copy, because that's the only arch we build for on this platform.
+# The hash is hard-coded here to mitigate the risk of supply-chain attacks.
+RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-x86_64.sh \
+         https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh && \
+    echo '8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake-linux-x86_64.sh' | sha256sum -c - && \
+    chmod +x ./cmake-linux-x86_64.sh && \
+    mkdir -p /cmake && \
+    ./cmake-linux-x86_64.sh --skip-license --prefix=/cmake
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/fedora-build.sh /build.sh

--- a/package-builders/entrypoint.sh
+++ b/package-builders/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -d /cmake/bin ]; then
+    PATH="/cmake/bin:${PATH}"
+fi
+
 fail() {
   printf "FAIL: %s\n" "$1"
   if [ -t 1 ]; then


### PR DESCRIPTION
Required to build packages for them with the new CMake build infrastructure.