### PR TITLE
Add ZSTD libraries to package builder images.

### DIFF
--- a/package-builders/Dockerfile.amazonlinux2.v1
+++ b/package-builders/Dockerfile.amazonlinux2.v1
@@ -37,6 +37,7 @@ RUN yum update -y && \
                    libtool \
                    libuuid-devel \
                    libuv-devel \
+                   libzstd-devel \
                    lm_sensors \
                    lz4-devel \
                    make \

--- a/package-builders/Dockerfile.amazonlinux2023.v1
+++ b/package-builders/Dockerfile.amazonlinux2023.v1
@@ -39,6 +39,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.centos-stream8.v1
+++ b/package-builders/Dockerfile.centos-stream8.v1
@@ -39,6 +39,7 @@ RUN dnf distro-sync -y --nodocs && \
         libuuid-devel \
         libuv-devel \
         libyaml-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.centos-stream9.v1
+++ b/package-builders/Dockerfile.centos-stream9.v1
@@ -38,6 +38,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.centos7.v1
+++ b/package-builders/Dockerfile.centos7.v1
@@ -39,6 +39,7 @@ RUN yum install -y epel-release && \
                    libtool \
                    libuuid-devel \
                    libuv-devel \
+                   libzstd-devel \
                    lm_sensors \
                    lz4-devel \
                    make \

--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -55,6 +55,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -54,6 +54,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -47,6 +47,7 @@ RUN apt-get update && \
                        libssl-dev \
                        libtool \
                        libuv1-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.fedora37.v1
+++ b/package-builders/Dockerfile.fedora37.v1
@@ -39,6 +39,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lz4-devel \
         make \
         ninja-build \

--- a/package-builders/Dockerfile.fedora38.v1
+++ b/package-builders/Dockerfile.fedora38.v1
@@ -39,6 +39,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lz4-devel \
         make \
         ninja-build \

--- a/package-builders/Dockerfile.fedora39.v1
+++ b/package-builders/Dockerfile.fedora39.v1
@@ -39,6 +39,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lz4-devel \
         make \
         ninja-build \

--- a/package-builders/Dockerfile.opensuse15.4.v1
+++ b/package-builders/Dockerfile.opensuse15.4.v1
@@ -43,6 +43,7 @@ RUN zypper update -y && \
                       libtool \
                       libuv-devel \
                       libuuid-devel \
+                      libzstd-devel \
                       make \
                       ninja \
                       patch \

--- a/package-builders/Dockerfile.opensuse15.5.v1
+++ b/package-builders/Dockerfile.opensuse15.5.v1
@@ -43,6 +43,7 @@ RUN zypper update -y && \
                       libtool \
                       libuv-devel \
                       libuuid-devel \
+                      libzstd-devel \
                       make \
                       ninja \
                       patch \

--- a/package-builders/Dockerfile.opensusetumbleweed.v1
+++ b/package-builders/Dockerfile.opensusetumbleweed.v1
@@ -42,6 +42,7 @@ RUN zypper update -y && \
                       libtool \
                       libuv-devel \
                       libuuid-devel \
+                      libzstd-devel \
                       make \
                       ninja \
                       patch \

--- a/package-builders/Dockerfile.oraclelinux8.v1
+++ b/package-builders/Dockerfile.oraclelinux8.v1
@@ -40,6 +40,7 @@ RUN dnf config-manager --set-enabled ol8_codeready_builder && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.oraclelinux9.v1
+++ b/package-builders/Dockerfile.oraclelinux9.v1
@@ -40,6 +40,7 @@ RUN dnf config-manager --set-enabled ol9_codeready_builder && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.rockylinux8.v1
+++ b/package-builders/Dockerfile.rockylinux8.v1
@@ -42,6 +42,7 @@ RUN dnf distro-sync -y --nodocs && \
         libuuid-devel \
         libuv-devel \
         libyaml-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.rockylinux9.v1
+++ b/package-builders/Dockerfile.rockylinux9.v1
@@ -41,6 +41,7 @@ RUN dnf distro-sync -y --nodocs && \
         libtool \
         libuuid-devel \
         libuv-devel \
+        libzstd-devel \
         lm_sensors \
         lz4-devel \
         make \

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -55,6 +55,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -54,6 +54,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.ubuntu23.04.v1
+++ b/package-builders/Dockerfile.ubuntu23.04.v1
@@ -54,6 +54,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -54,6 +54,7 @@ RUN apt-get update && \
                        libtool \
                        libuv1-dev \
                        libxen-dev \
+                       libzstd-dev \
                        make \
                        ninja-build \
                        pkg-config \


### PR DESCRIPTION
They are already present in the OCI base images and static-builder images.