### PR TITLE
Add ncurse-static to our static builds

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -36,6 +36,7 @@ RUN apk add --no-cache \
     mongo-c-driver-static \
     musl-fts-dev \
     ncurses \
+    ncurses-static \
     netcat-openbsd \
     ninja \
     openssh \


### PR DESCRIPTION
Fix bash dependency for static builds
