### PR TITLE
Revert "Bump alpine from 3.18 to 3.19 in /static-builder"

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.18
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"


### PR DESCRIPTION
Reverts netdata/helper-images#257

This unexpectedly broke our static builds.