### PR TITLE
static builder: add snappy.pc

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -55,4 +55,4 @@ RUN apk add --no-cache \
     zstd-dev \
     zstd-static
 
-COPY snappy.pc /usr/lib/pkgconfig
+COPY static-builder/snappy.pc /usr/lib/pkgconfig/snappy.pc

--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -54,3 +54,5 @@ RUN apk add --no-cache \
     zlib-static \
     zstd-dev \
     zstd-static
+
+COPY snappy.pc /usr/lib/pkgconfig

--- a/static-builder/snappy.pc
+++ b/static-builder/snappy.pc
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: snappy
+Description: A library for compressing and decompressing snappy data
+Version: 1.1.10
+Libs: -L${libdir} -lsnappy
+Cflags: -I${includedir}


### PR DESCRIPTION
Fixes: netdata/netdata#16677

The upstream snappy sources don’t include a pkg-config file.

Test:
 - build `netdata/static-builder:v1` using this branch.
 - build/install Netdata static.
 - check Prometheus remote write in the build info - OK.
 - configure Prometheus remote write exporter, and make sure that it exports data - OK.