### PR TITLE
Add sentry-cli to all deb based system 

### DIFF
--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -70,6 +70,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -69,7 +69,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -69,6 +69,8 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -69,7 +69,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -68,6 +68,8 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -69,6 +69,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -65,6 +65,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -64,7 +64,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -64,7 +64,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -64,6 +64,8 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -78,6 +78,8 @@ RUN if dpkg-architecture --is 'armhf'; then \
         apt-get upgrade -y ; \
     fi
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -78,7 +78,7 @@ RUN if dpkg-architecture --is 'armhf'; then \
         apt-get upgrade -y ; \
     fi
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN wget -O /tmp/get-sentry.sh https://sentry.io/get-cli/ && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -78,7 +78,7 @@ RUN if dpkg-architecture --is 'armhf'; then \
         apt-get upgrade -y ; \
     fi
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -78,7 +78,7 @@ RUN if dpkg-architecture --is 'armhf'; then \
         apt-get upgrade -y ; \
     fi
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -79,6 +79,7 @@ RUN if dpkg-architecture --is 'armhf'; then \
     fi
 
 RUN wget -O /tmp/get-sentry.sh https://sentry.io/get-cli/ && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -68,6 +68,8 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -69,6 +69,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -68,6 +68,8 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
+RUN curl -sL https://sentry.io/get-cli/ | sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh
 

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -69,6 +69,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
+RUN rm /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://sentry.io/get-cli/ | sh
+RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -68,7 +68,7 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -o pipefail && curl -sL https://sentry.io/get-cli/ | sh
+RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh


### PR DESCRIPTION
Add sentry-cli to all deb based system (exclude ubuntu 23.04, upcoming eol)