### PR TITLE
Clean up installation of Sentry in package-builders.

### DIFF
--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -69,8 +69,9 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -68,8 +68,9 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -64,8 +64,9 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -78,8 +78,9 @@ RUN if dpkg-architecture --is 'armhf'; then \
         apt-get upgrade -y ; \
     fi
 
-RUN wget -O /tmp/get-sentry.sh https://sentry.io/get-cli/ && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -68,8 +68,9 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -68,8 +68,9 @@ RUN apt-get update && \
     c_rehash && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl https://sentry.io/get-cli/ > /tmp/get-sentry.sh && sh /tmp/get-sentry.sh
-RUN rm /tmp/get-sentry.sh
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/debian-build.sh /build.sh


### PR DESCRIPTION
- Use the same command for downloading regardless of distro.
- Add options to ensure that cURL handles issues properly and fails cleanly in error cases.
- Use one line per command (easier to read and reason about).
- Remove the install script in the same RUN step that added it so that it doesn’t actually contribute to the final image size and also avoids a pointless extra layer.