### PR TITLE
Only copy debian directory if needed.

### DIFF
--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -29,7 +29,10 @@ cp -a /netdata /usr/src || exit 1
 rm -rf /usr/src/netdata/.git || exit 1
 cd /usr/src/netdata || exit 1
 
-cp -a contrib/debian debian || exit 1
+# If the `debian` directory is not in the root of the source tree, copy it there.
+if [ ! -d debian ]; then
+    cp -a contrib/debian debian || exit 1
+fi
 
 # If there's a specific control file for this OS release, use it
 if [ -e "debian/control.${CODENAME}" ]; then


### PR DESCRIPTION
This is preparation for moving the `contrib/debian` directory to the root of the source tree, where all Debian tooling expects it to be.

With this PR, the package builders will correctly handle both the existing structure of the repo and the planned updated structure.