### PR TITLE
Add libpsl-static to static builders

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -29,6 +29,7 @@ RUN apk add --no-cache \
     libtool \
     libuv-dev \
     libuv-static \
+    libpsl-static \
     lz4-dev \
     lz4-static \
     make \


### PR DESCRIPTION
It's an attempt, during updating OpenSSL and curl for our static builds fail because this package is missing.

Merging it after upcoming nightly build