### PR TITLE
Add handling of golang deps to package builder images.

### DIFF
--- a/package-builders/debian-build.sh
+++ b/package-builders/debian-build.sh
@@ -39,6 +39,10 @@ if [ -e "debian/control.${CODENAME}" ]; then
   cp "debian/control.${CODENAME}" debian/control || exit 1
 fi
 
+# Remove the build dependency on Golang, since we provide our own
+# toolchain for that independent of the distro packages.
+sed -i -e '/^ *golang.*,$/d' debian/control
+
 # If the changelog was not updated on the host, assume this is a
 # development build and update the changelog appropriately.
 # shellcheck disable=SC2153

--- a/package-builders/fedora-build.sh
+++ b/package-builders/fedora-build.sh
@@ -30,12 +30,15 @@ cat > "/root/rpmbuild/SOURCES/netdata-${pkg_version}/system/.install-type" <<-EO
 	EOF
 
 # Download Sources
-rpmbuild --nobuild --define "_topdir /root/rpmbuild/SOURCES" \
---define "_sourcedir /root/rpmbuild/SOURCES" \
---define "source_date_epoch_from_changelog false" \
---undefine "_disable_source_fetch" "/root/rpmbuild/SPECS/netdata.spec" || exit 1
+rpmbuild --nobuild \
+         --define "_upstream_go_toolchain 1" \
+         --define "_topdir /root/rpmbuild/SOURCES" \
+         --define "_sourcedir /root/rpmbuild/SOURCES" \
+         --define "source_date_epoch_from_changelog false" \
+         --undefine "_disable_source_fetch" \
+         "/root/rpmbuild/SPECS/netdata.spec" || exit 1
 
-rpmbuild -bb --rebuild /root/rpmbuild/SPECS/netdata.spec || exit 1
+rpmbuild -bb --define "_upstream_go_toolchain 1" --rebuild /root/rpmbuild/SPECS/netdata.spec || exit 1
 
 # Copy the built packages to /netdata/artifacts (which may be bind-mounted)
 # Also ensure /netdata/artifacts exists and create it if it doesn't

--- a/package-builders/suse-build.sh
+++ b/package-builders/suse-build.sh
@@ -30,12 +30,15 @@ cat > "/usr/src/packages/SOURCES/netdata-${pkg_version}/system/.install-type" <<
 	EOF
 
 # Download Sources
-rpmbuild --nobuild --define "_topdir /usr/src/packages/SOURCES" \
---define "_sourcedir /usr/src/packages/SOURCES" \
---define "source_date_epoch_from_changelog false" \
---undefine "_disable_source_fetch" "/usr/src/packages/SPECS/netdata.spec" || exit 1
+rpmbuild --nobuild \
+         --define "_upstream_go_toolchain 1" \
+         --define "_topdir /usr/src/packages/SOURCES" \
+         --define "_sourcedir /usr/src/packages/SOURCES" \
+         --define "source_date_epoch_from_changelog false" \
+         --undefine "_disable_source_fetch" \
+         "/usr/src/packages/SPECS/netdata.spec" || exit 1
 
-rpmbuild -bb --rebuild /usr/src/packages/SPECS/netdata.spec || exit 1
+rpmbuild -bb --define "_upstream_go_toolchain 1" --rebuild /usr/src/packages/SPECS/netdata.spec || exit 1
 
 # Copy the built packages to /netdata/artifacts (which may be bind-mounted)
 # Also ensure /netdata/artifacts exists and create it if it doesn't


### PR DESCRIPTION
This will be needed by the upcoming Go plugin integration in our packaging code.

We need to explicitly list Go as a build dependency in our packaging files so that users who build without using our package builders have things fail cleanly, but we need to mask that build dependency when building in our package builders since we universally use a copy of the official Go toolchain instead of the distro-provided toolchain to ensure that we have a working toolchain.

For DEB packages, this requires modifying the `debian/control` file in-place before building to remove the dependency.

For RPM packages, we instead use a macro that is only defined by our build infrastructure at build time to skip those dependencies.