### PR TITLE
Make debhelper an explicit dependency in Debian/Ubuntu package builders

### DIFF
--- a/package-builders/Dockerfile.debian10.v1
+++ b/package-builders/Dockerfile.debian10.v1
@@ -26,6 +26,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \

--- a/package-builders/Dockerfile.debian11.v1
+++ b/package-builders/Dockerfile.debian11.v1
@@ -26,6 +26,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dpkg-dev \

--- a/package-builders/Dockerfile.debian12.v1
+++ b/package-builders/Dockerfile.debian12.v1
@@ -20,6 +20,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dpkg-dev \

--- a/package-builders/Dockerfile.ubuntu20.04.v1
+++ b/package-builders/Dockerfile.ubuntu20.04.v1
@@ -26,6 +26,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dh-systemd \

--- a/package-builders/Dockerfile.ubuntu22.04.v1
+++ b/package-builders/Dockerfile.ubuntu22.04.v1
@@ -26,6 +26,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dpkg-dev \

--- a/package-builders/Dockerfile.ubuntu23.10.v1
+++ b/package-builders/Dockerfile.ubuntu23.10.v1
@@ -26,6 +26,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dh-autoreconf \
                        dh-make \
                        dpkg-dev \

--- a/package-builders/Dockerfile.ubuntu24.04.v1
+++ b/package-builders/Dockerfile.ubuntu24.04.v1
@@ -23,6 +23,7 @@ RUN apt-get update && \
                        ca-certificates \
                        cmake \
                        curl \
+                       debhelper \
                        dpkg-dev \
                        flex \
                        g++ \


### PR DESCRIPTION
We actually depend on it in our package build process, but it was not explicitly listed in the pacakges we were installing, instead being pulled in as an implicit transitive dependency of the debhelper plugins we pulled in (which we don’t actually _need_ anymore).