### PR TITLE
remove using of netdata/packaging/go.d.version

### DIFF
--- a/package-builders/fedora-build.sh
+++ b/package-builders/fedora-build.sh
@@ -20,7 +20,6 @@ sed -i "s/\${RPM_BUILD_DIR}\/%{name}-%{version}/\${RPM_BUILD_DIR}/g" /root/rpmbu
 
 # This updates the version in the spec file appropriately.
 sed -i "s/@PACKAGE_VERSION@/${pkg_version}/g" /root/rpmbuild/SPECS/netdata.spec || exit 1
-sed -i "s/@GO_PACKAGE_VERSION@/$(< /netdata/packaging/go.d.version sed -e 's|v||g')/g" /root/rpmbuild/SPECS/netdata.spec || exit 1
 
 # Properly mark the installation type.
 cat > "/root/rpmbuild/SOURCES/netdata-${pkg_version}/system/.install-type" <<-EOF

--- a/package-builders/suse-build.sh
+++ b/package-builders/suse-build.sh
@@ -20,7 +20,6 @@ sed -i "s/\${RPM_BUILD_DIR}\/%{name}-%{version}/\${RPM_BUILD_DIR}/g" /usr/src/pa
 
 # This updates the version in the spec file appropriately.
 sed -i "s/@PACKAGE_VERSION@/${pkg_version}/g" /usr/src/packages/SPECS/netdata.spec || exit 1
-sed -i "s/@GO_PACKAGE_VERSION@/$(< /netdata/packaging/go.d.version sed -e 's|v||g')/g" /usr/src/packages/SPECS/netdata.spec || exit 1
 
 # Properly mark the installation type.
 cat > "/usr/src/packages/SOURCES/netdata-${pkg_version}/system/.install-type" <<-EOF


### PR DESCRIPTION
Just noticed the

> /build.sh: line 23: /netdata/packaging/go.d.version: No such file or directory

error in the netdata/netdata ci logs and decided to fix it!

