### PR TITLE
Add DEB package builders for new CPack infra.

### DIFF
--- a/.github/data/matrices.yaml
+++ b/.github/data/matrices.yaml
@@ -59,7 +59,9 @@ package-builders:
         - linux/amd64
     - &debian
       os: debian12
-      revisions: *pkg-builder-revs
+      revisions: &deb-pkg-builder-revs
+        - v1
+        - v2
       platforms:
         - linux/amd64
         - linux/386
@@ -107,7 +109,7 @@ package-builders:
       os: rockylinux8
     - &ubuntu
       os: ubuntu24.04
-      revisions: *pkg-builder-revs
+      revisions: *deb-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm/v7

--- a/package-builders/Dockerfile.debian10.v2
+++ b/package-builders/Dockerfile.debian10.v2
@@ -1,0 +1,80 @@
+FROM debian:buster
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Debian 10"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Debian 10"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to ensure package installs don't prompt for any user input.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       debhelper \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcups2-dev \
+                       libcurl4-openssl-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian11.v2
+++ b/package-builders/Dockerfile.debian11.v2
@@ -1,0 +1,79 @@
+FROM debian:bullseye
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Debian 11"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Debian 11"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to ensure package installs don't prompt for any user input.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcurl4-openssl-dev \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.debian12.v2
+++ b/package-builders/Dockerfile.debian12.v2
@@ -1,0 +1,74 @@
+FROM debian:bookworm
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to ensure package installs don't prompt for any user input.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcurl4-openssl-dev \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    if ! dpkg-architecture --is 'i386'; then \
+        apt-get install -y --no-install-recommends libxen-dev ; \
+    fi && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu20.04.v2
+++ b/package-builders/Dockerfile.ubuntu20.04.v2
@@ -1,0 +1,88 @@
+FROM ubuntu:20.04
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Ubuntu 20.04"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Ubuntu 20.04"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcurl4-openssl-dev \
+                       libcups2-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if dpkg-architecture --is 'armhf'; then \
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee -a /etc/apt/sources.list.d/kitware.list >/dev/null && \
+        apt-get update && \
+        rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
+        apt-get install -y --no-install-recommends kitware-archive-keyring && \
+        apt-get upgrade -y ; \
+    fi
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu22.04.v2
+++ b/package-builders/Dockerfile.ubuntu22.04.v2
@@ -1,0 +1,79 @@
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Ubuntu 22.04"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Ubuntu 22.04"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcups2-dev \
+                       libcurl4-openssl-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu23.10.v2
+++ b/package-builders/Dockerfile.ubuntu23.10.v2
@@ -1,0 +1,79 @@
+FROM ubuntu:23.10
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Ubuntu 23.10"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Ubuntu 23.10"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcups2-dev \
+                       libcurl4-openssl-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu24.04.v2
+++ b/package-builders/Dockerfile.ubuntu24.04.v2
@@ -1,0 +1,82 @@
+FROM ubuntu:24.04
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Ubuntu 24.04"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Ubuntu 24.04"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       debhelper \
+                       dpkg-dev \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-buildpackage \
+                       git-core \
+                       libatomic1 \
+                       libcups2-dev \
+                       libcurl4-openssl-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/debian-build.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/cpack-deb.sh
+++ b/package-builders/cpack-deb.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+SRC_DIR=/usr/src/netdata
+BUILD_DIR=/build
+
+cp -a /netdata "${SRC_DIR}" || exit 1
+rm -rf "${SRC_DIR}/.git" || exit 1
+
+# Properly mark the installation type.
+cat > "${SRC_DIR}/system/.install-type" <<-EOF
+	INSTALL_TYPE='binpkg-deb'
+	PREBUILT_ARCH='$(uname -m)'
+	PREBUILT_DISTRO='${DISTRO} ${DISTRO_VERSION}'
+	EOF
+
+"${SRC_DIR}/packaging/build-package.sh" DEB "${BUILD_DIR}"
+
+# Embed distro info in package name.
+# This is required to make the repo actually standards compliant wthout packageclouds hacks.
+distid="${DISTNAME}${DISTVERS}"
+for pkg in "${BUILD_DIR}"/*.deb; do
+  pkgname="$(basename "${pkg}" .deb)"
+  name="$(echo "${pkgname}" | cut -f 1 -d '_')"
+  version="$(echo "${pkgname}" | cut -f 2 -d '_')"
+  arch="$(echo "${pkgname}" | cut -f 3 -d '_')"
+
+  newname="$(dirname "${pkgname}")/${name}_${version}+${distid}_${arch}.deb"
+  mv "${pkg}" "${newname}"
+done
+
+# Copy the built packages to /netdata/artifacts (which may be bind-mounted)
+# Also ensure /netdata/artifacts exists and create it if it doesn't
+[ -d /netdata/artifacts ] || mkdir -p /netdata/artifacts
+cp -a "${BUILD_DIR}"/*.deb /netdata/artifacts/ || exit 1
+
+# Correct ownership of the artifacts.
+# Without this, the artifacts directory and it's contents end up owned
+# by root instead of the local user on Linux boxes
+chown -R --reference=/netdata /netdata/artifacts


### PR DESCRIPTION
Actual build will be handled by a script in the agent source tree, but we still need the basic infra around it in the package builders.