### PR TITLE
Assorted fixes for the static builder image.

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
     binutils \
     bison \
     cmake \
+    coreutils \
     curl \
     curl-static \
     elfutils-dev \
@@ -24,7 +25,7 @@ RUN apk add --no-cache \
     gzip \
     jq \
     libelf-static \
-    libidn2-dev \ 
+    libidn2-dev \
     libidn2-static \
     libmnl-dev \
     libmnl-static \
@@ -44,11 +45,11 @@ RUN apk add --no-cache \
     ncurses \
     ncurses-static \
     netcat-openbsd \
-    ninja \
     openssh \
     pcre2-dev \
     pkgconfig \
     protobuf-dev \
+    samurai \
     snappy-dev \
     snappy-static \
     util-linux-dev \


### PR DESCRIPTION
- Add coreutils (needed by libbpf build)
- Pull in the correct package to get a working `ninja` command for builds.
- Remove trailing spaces.