### PR TITLE
Add legacy image for CentOS.

### DIFF
--- a/.github/data/matrices.yaml
+++ b/.github/data/matrices.yaml
@@ -113,3 +113,13 @@ package-builders:
       os: ubuntu22.04
     - <<: *ubuntu
       os: ubuntu20.04
+legacy:
+  image: legacy
+  distros:
+    - os: centos7
+      platforms:
+        - linux/386
+        - linux/amd64
+        - linux/arm/v7
+        - linux/arm64/v8
+        - linux/ppc64le

--- a/.github/scripts/gen-matrix-legacy.py
+++ b/.github/scripts/gen-matrix-legacy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
+entries = []
+
+with open('.github/data/matrices.yaml') as f:
+    data = yaml.load(f)
+
+pkgs = data['legacy']
+meta = data['meta']
+
+entries = []
+
+match sys.argv[1]:
+    case 'build':
+        for distro in pkgs['distros']:
+            entries.append({
+                'os': distro['os'],
+            })
+    case 'pr':
+        for distro in pkgs['distros']:
+            for platform in [x for x in distro['platforms'] if x != meta['native-platform']]:
+                entries.append({
+                    'os': distro['os'],
+                    'platform': platform,
+                })
+    case 'publish':
+        for distro in pkgs['distros']:
+            tags = []
+
+            for registry in meta['registries']:
+                tags.append(f'{registry}{meta["image-prefix"]}{pkgs["image"]}:{distro["os"]}')
+
+            entries.append({
+                'os': distro['os'],
+                'platforms': ','.join(distro['platforms']),
+                'tags': ','.join(tags)
+            })
+    case _:
+        raise ValueError(f'Unrecognized matrix type {sys.argv[1]}')
+
+entries.sort(key=lambda k: k['revision'])
+matrix = json.dumps({'include': entries}, sort_keys=True)
+print(matrix)

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,0 +1,188 @@
+---
+# Builds our legacy Docker images.
+name: Legacy Images
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    branches:
+      - 'master'
+  pull_request:
+concurrency:
+  group: legacy-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  file-check: # Check what files changed if we’re being run in a PR or on a push.
+    name: Check Modified Files
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      run: ${{ steps.check-run.outputs.run }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Check files
+        id: check-files
+        uses: tj-actions/changed-files@v43
+        with:
+          since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
+          files: |
+            .github/data/matrices.yml
+            .github/workflows/legacy.yml
+            legacy/**
+      - name: Check Run
+        id: check-run
+        run: |
+          if [ "${{ steps.check-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'run=false' >> "${GITHUB_OUTPUT}"
+          fi
+
+  matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.build.outputs.matrix }}
+      pr-matrix: ${{ steps.pr.outputs.matrix }}
+      publish-matrix: ${{ steps.publish.outputs.matrix }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+      - name: Prepare tools
+        id: prepare
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y python3-ruamel.yaml
+      - name: Prepare Build Check Matrix
+        id: build
+        run: |
+          matrix="$(.github/scripts/gen-matrix-legacy.py build)"
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+      - name: Prepare PR Check Matrix
+        id: pr
+        run: |
+          matrix="$(.github/scripts/gen-matrix-legacy.py pr)"
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+      - name: Prepare Publish Matrix
+        id: publish
+        run: |
+          matrix="$(.github/scripts/gen-matrix-legacy.py publish)"
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  build-check:
+    name: Build Check
+    if: github.event_name == 'pull_request'
+    needs:
+      - file-check
+      - matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.build-matrix) }}
+      max-parallel: 8
+      fail-fast: false
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - name: Setup Buildx
+        if: needs.file-check.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Docker Build
+        if: needs.file-check.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          load: false
+          push: false
+          file: ./legacy/Dockerfile.${{ matrix.os }}
+          tags: netdata/package-builders:${{ matrix.os }}
+
+  pr-checks:
+    name: PR Checks
+    if: github.event_name == 'pull_request'
+    needs:
+      - file-check
+      - build-check
+      - matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.pr-matrix) }}
+      max-parallel: 8
+      fail-fast: false
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - name: Setup QEMU
+        if: matrix.platform != 'linux/i386' && needs.file-check.outputs.run == 'true'
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Buildx
+        if: needs.file-check.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        if: needs.file-check.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          load: false
+          push: false
+          file: ./legacy/Dockerfile.${{ matrix.os }}
+          tags: netdata/package-builders:${{ matrix.os }}
+
+  publish:
+    name: Publish Images
+    if: github.event_name == 'push' || (github.event_name == 'schedule' && github.repository == 'netdata/helper-images')
+    runs-on: ubuntu-latest
+    needs:
+      - matrix
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.publish-matrix) }}
+      max-parallel: 8
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker Hub Login
+        uses: docker/login-action@v3
+        with:
+          username: netdatabot
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: GitHub Container Registry Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Quay.io Login
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.NETDATABOT_QUAY_USERNAME }}
+          password: ${{ secrets.NETDATABOT_QUAY_TOKEN }}
+      - name: Docker Build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platforms }}
+          push: true
+          file: ./legacy/Dockerfile.${{ matrix.os }}
+          tags: ${{ matrix.tags }}

--- a/legacy/Dockerfile.centos7
+++ b/legacy/Dockerfile.centos7
@@ -1,0 +1,9 @@
+FROM centos:7
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata CentOS 7 Legacy image"
+LABEL org.opencontainers.image.description="Base image for CentOS 7 with core repositories updated to use vault.centos.org"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+COPY legacy/centos-7.repo /etc/yum.repos.d/CentOS-Base.repo

--- a/legacy/centos-7.repo
+++ b/legacy/centos-7.repo
@@ -1,0 +1,43 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+[base]
+name=CentOS-$releasever - Base
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7


### PR DESCRIPTION
This is required for us to continue reliably publishing CentOS 7 packages for existing releases which we need to have support for it on.