### PR TITLE
add mailutils and msmtp-mta

### DIFF
--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -46,6 +46,8 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     libzstd1 \
                     lm-sensors \
                     msmtp \
+                    msmtp-mta \
+                    mailutils \
                     vim-tiny \
                     ncurses-base \
                     netcat-openbsd \


### PR DESCRIPTION
With just `msmtp` it didn't work to follow the instructions and make it work. 

Personally I user Protonmail for sending emails, and with these to installed, the `/usr/libexec/netdata/plugins.d/alarm-notify.sh test` was successful.