### PR TITLE
Add dpkg-dev to Docker builder image (for `dpkg-architecture` command).

### DIFF
--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -25,6 +25,7 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
     apt-get install -y --no-install-recommends \
                     ca-certificates \
                     curl \
+                    dpkg-dev \
                     fping \
                     iproute2 \
                     jq \
@@ -40,7 +41,6 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     libssl3 \
                     libsystemd0 \
                     libuuid1 \
-                    libunwind8 \
                     libuv1 \
                     libvirt-clients \
                     libyaml-0-2 \
@@ -55,7 +55,12 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     procps \
                     python3 \
                     zlib1g && \
-    if [ "$(uname -m)" != "ppc64le" ]; then \
-        apt-get install -y --no-install-recommends freeipmi libipmimonitoring6 || exit 1 ; \
+    if ! dpkg-architecture --equal ppc64el; then \
+        apt-get install -y --no-install-recommends freeipmi libipmimonitoring6 ; \
     fi && \
+    if ! dpkg-architecture --equal i386; then \
+        apt-get install -y --no-install-recommends libunwind8 ; \
+    fi && \
+    apt-get purge -y dpkg-dev && \
+    apt-get autoremove --purge -y && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*

--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -31,6 +31,7 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     ca-certificates \
                     cmake \
                     curl \
+                    dpkg-dev \
                     flex \
                     git \
                     jq \
@@ -47,7 +48,6 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     libssl-dev \
                     libsystemd-dev \
                     libtool \
-                    libunwind-dev \
                     libuv1-dev \
                     libyaml-dev \
                     libzstd-dev \
@@ -60,8 +60,11 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     python3-dev \
                     uuid-dev \
                     zlib1g-dev && \
-    if [ "$(uname -m)" != "ppc64le" ]; then \
-        apt-get install -y --no-install-recommends libfreeipmi-dev libipmimonitoring-dev || exit 1 ; \
+    if ! dpkg-architecture --equals ppc64el; then \
+        apt-get install -y --no-install-recommends libfreeipmi-dev libipmimonitoring-dev ; \
+    fi && \
+    if ! dpkg-architecture --equals i386; then \
+        apt-get install -y --no-install-recommends libunwind-dev ; \
     fi && \
     mkdir -p /deps/etc && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*


### PR DESCRIPTION
Also tweak the cases where we were checking `uname -m` to use `dpkg-architecture --equals` instead, as it is far more reliable.