### PR TITLE
Drop libunwind from v1 static builders and include build deps for it to be vendored at build time.

### DIFF
--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -30,8 +30,6 @@ RUN apk add --no-cache \
     libmnl-dev \
     libmnl-static \
     libtool \
-    libunwind-dev \
-    libunwind-static \
     libuv-dev \
     libuv-static \
     libpsl-dev \
@@ -58,6 +56,7 @@ RUN apk add --no-cache \
     util-linux-dev \
     wget \
     xz \
+    xz-static \
     yaml-dev \
     yaml-static \
     zlib-dev \


### PR DESCRIPTION
SSIA