### PR TITLE
Package builder updates.

### DIFF
--- a/.github/data/matrices.yaml
+++ b/.github/data/matrices.yaml
@@ -8,8 +8,10 @@ meta:
     - 'ghcr.io/'
     - 'quay.io/'
 anchors:
-  pkg-builder-revs: &pkg-builder-revs
+  rpm-pkg-builder-revs: &rpm-pkg-builder-revs
     - v1
+    - v2
+  deb-pkg-builder-revs: &deb-pkg-builder-revs
     - v2
 static:
   image: static-builder
@@ -45,7 +47,7 @@ package-builders:
   distros:
     - &amzn
       os: amazonlinux2023
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
@@ -53,19 +55,19 @@ package-builders:
       os: amazonlinux2
     - &centos-stream
       os: centos-stream10
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
     - <<: *centos-stream
       os: centos-stream9
     - os: centos7
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
     - &debian
       os: debian12
-      revisions: *pkg-builder-revs
+      revisions: *deb-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/386
@@ -75,7 +77,7 @@ package-builders:
       os: debian11
     - &fedora
       os: fedora42
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
@@ -85,7 +87,7 @@ package-builders:
       os: fedora40
     - &opensuse
       os: opensusetumbleweed
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
@@ -93,7 +95,7 @@ package-builders:
       os: opensuse15.6
     - &oracle
       os: oraclelinux9
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
@@ -101,7 +103,7 @@ package-builders:
       os: oraclelinux8
     - &rocky
       os: rockylinux9
-      revisions: *pkg-builder-revs
+      revisions: *rpm-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
@@ -109,7 +111,7 @@ package-builders:
       os: rockylinux8
     - &ubuntu
       os: ubuntu24.04
-      revisions: *pkg-builder-revs
+      revisions: *deb-pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm/v7

--- a/.github/data/matrices.yaml
+++ b/.github/data/matrices.yaml
@@ -52,11 +52,13 @@ package-builders:
     - <<: *amzn
       os: amazonlinux2
     - &centos-stream
-      os: centos-stream9
+      os: centos-stream10
       revisions: *pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
+    - <<: *centos-stream
+      os: centos-stream9
     - os: centos7
       revisions: *pkg-builder-revs
       platforms:
@@ -71,18 +73,16 @@ package-builders:
         - linux/arm64/v8
     - <<: *debian
       os: debian11
-    - <<: *debian
-      os: debian10
     - &fedora
-      os: fedora41
+      os: fedora42
       revisions: *pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm64/v8
     - <<: *fedora
-      os: fedora40
+      os: fedora41
     - <<: *fedora
-      os: fedora39
+      os: fedora40
     - &opensuse
       os: opensusetumbleweed
       revisions: *pkg-builder-revs
@@ -91,8 +91,6 @@ package-builders:
         - linux/arm64/v8
     - <<: *opensuse
       os: opensuse15.6
-    - <<: *opensuse
-      os: opensuse15.5
     - &oracle
       os: oraclelinux9
       revisions: *pkg-builder-revs
@@ -110,14 +108,16 @@ package-builders:
     - <<: *rocky
       os: rockylinux8
     - &ubuntu
-      os: ubuntu24.10
+      os: ubuntu24.04
       revisions: *pkg-builder-revs
       platforms:
         - linux/amd64
         - linux/arm/v7
         - linux/arm64/v8
     - <<: *ubuntu
-      os: ubuntu24.04
+      os: ubuntu25.04
+    - <<: *ubuntu
+      os: ubuntu24.10
     - <<: *ubuntu
       os: ubuntu22.04
     - <<: *ubuntu

--- a/package-builders/Dockerfile.centos-stream10.v1
+++ b/package-builders/Dockerfile.centos-stream10.v1
@@ -1,0 +1,87 @@
+FROM quay.io/centos/centos:stream10
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for CentOS-Stream 10"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for CentOS-Stream 10"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV VERSION=$VERSION
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf install -y --nodocs 'dnf-command(config-manager)' epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf clean packages && \
+    dnf install -y --allowerasing --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        automake \
+        bash \
+        bison \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        flex \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git \
+        json-c-devel \
+        libcurl-devel \
+        libyaml-devel \
+        libatomic \
+        libmnl-devel \
+        libtool \
+        libunwind-devel \
+        libuuid-devel \
+        libuv-devel \
+        libzstd-devel \
+        lm_sensors \
+        lz4-devel \
+        make \
+        ninja-build \
+        nc \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pcre2-devel \
+        pkgconfig \
+        'pkgconfig(libmongoc-1.0)' \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-pyyaml \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        systemd-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+COPY scripts/install-rust.sh /install-rust.sh
+RUN /install-rust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -1,0 +1,86 @@
+FROM quay.io/centos/centos:stream10
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for CentOS-Stream 10"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for CentOS-Stream 10"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV VERSION=$VERSION
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf install -y --nodocs 'dnf-command(config-manager)' epel-release && \
+    dnf config-manager --set-enabled crb && \
+    dnf clean packages && \
+    dnf install -y --allowerasing --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        autoconf \
+        autoconf-archive \
+        automake \
+        bash \
+        bison \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        flex \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git \
+        json-c-devel \
+        libcurl-devel \
+        libyaml-devel \
+        libatomic \
+        libmnl-devel \
+        libtool \
+        libunwind-devel \
+        libuuid-devel \
+        libuv-devel \
+        libzstd-devel \
+        lm_sensors \
+        lz4-devel \
+        make \
+        ninja-build \
+        nc \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pcre2-devel \
+        pkgconfig \
+        'pkgconfig(libmongoc-1.0)' \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        python3 \
+        python3-pyyaml \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        systemd-devel \
+        wget \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-rpm.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+COPY scripts/install-rust.sh /install-rust.sh
+RUN /install-rust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora42.v1
+++ b/package-builders/Dockerfile.fedora42.v1
@@ -1,0 +1,79 @@
+FROM fedora:42
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Fedora 42"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Fedora 42"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV VERSION=$VERSION
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        bash \
+        bison \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        flex \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        json-c-devel \
+        libyaml-devel \
+        Judy-devel \
+        libatomic \
+        libcurl-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libunwind-devel \
+        libuuid-devel \
+        libuv-devel \
+        libzstd-devel \
+        lz4-devel \
+        make \
+        ninja-build \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pcre2-devel \
+        pkgconfig \
+        'pkgconfig(libmongoc-1.0)' \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpm-build \
+        rpm-devel \
+        rpmdevtools \
+        snappy-devel \
+        systemd-devel \
+        xen-devel \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash && \
+    mkdir -p /root/rpmbuild/BUILD /root/rpmbuild/RPMS /root/rpmbuild/SOURCES /root/rpmbuild/SPECS /root/rpmbuild/SRPMS
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/fedora-build.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+COPY scripts/install-rust.sh /install-rust.sh
+RUN /install-rust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora42.v2
+++ b/package-builders/Dockerfile.fedora42.v2
@@ -1,0 +1,77 @@
+FROM fedora:42
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Fedora 42"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official RPM packages for Fedora 42"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV VERSION=$VERSION
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN dnf distro-sync -y --nodocs && \
+    dnf clean -y packages && \
+    dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
+        bash \
+        bison \
+        cmake \
+        cups-devel \
+        curl \
+        diffutils \
+        elfutils-libelf-devel \
+        findutils \
+        flex \
+        freeipmi-devel \
+        gcc \
+        gcc-c++ \
+        git-core \
+        json-c-devel \
+        libyaml-devel \
+        Judy-devel \
+        libatomic \
+        libcurl-devel \
+        libmnl-devel \
+        libnetfilter_acct-devel \
+        libunwind-devel \
+        libuuid-devel \
+        libuv-devel \
+        libzstd-devel \
+        lz4-devel \
+        make \
+        ninja-build \
+        openssl-devel \
+        openssl-perl \
+        patch \
+        pcre2-devel \
+        pkgconfig \
+        'pkgconfig(libmongoc-1.0)' \
+        procps \
+        protobuf-c-devel \
+        protobuf-compiler \
+        protobuf-devel \
+        rpmdevtools \
+        snappy-devel \
+        systemd-devel \
+        systemd-rpm-macros \
+        xen-devel \
+        zlib-devel && \
+    rm -rf /var/cache/dnf && \
+    c_rehash
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-rpm.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+COPY scripts/install-rust.sh /install-rust.sh
+RUN /install-rust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu25.04.v2
+++ b/package-builders/Dockerfile.ubuntu25.04.v2
@@ -1,0 +1,87 @@
+FROM ubuntu:25.04
+
+LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
+LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"
+LABEL org.opencontainers.image.title="Netdata Package Builder for Ubuntu 25.04"
+LABEL org.opencontainers.image.description="Package builder image for Netdata official DEB packages for Ubuntu 25.04"
+LABEL org.opencontainers.image.vendor="Netdata Inc."
+
+ENV EMAIL=bot@netdata.cloud
+ENV FULLNAME="Netdata Builder"
+ENV VERSION=0.1
+
+# This is needed to keep package installs from prompting about configuration.
+ENV DEBIAN_FRONTEND=noninteractive
+# Dummy Sentry DSN
+ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+                       bison \
+                       build-essential \
+                       ca-certificates \
+                       cmake \
+                       curl \
+                       dpkg-dev \
+                       file \
+                       flex \
+                       g++ \
+                       gcc \
+                       git-core \
+                       libatomic1 \
+                       libcups2-dev \
+                       libcurl4-openssl-dev \
+                       libdistro-info-perl \
+                       libelf-dev \
+                       libipmimonitoring-dev \
+                       libjson-c-dev \
+                       libyaml-dev \
+                       libjudy-dev \
+                       liblz4-dev \
+                       libmnl-dev \
+                       libmongoc-dev \
+                       libnetfilter-acct-dev \
+                       libpcre2-dev \
+                       libprotobuf-dev \
+                       libprotoc-dev \
+                       libsnappy-dev \
+                       libsystemd-dev \
+                       libssl-dev \
+                       libunwind-dev \
+                       libuv1-dev \
+                       libxen-dev \
+                       libzstd-dev \
+                       make \
+                       ninja-build \
+                       patch \
+                       pkg-config \
+                       protobuf-compiler \
+                       systemd \
+                       uuid-dev \
+                       wget \
+                       zlib1g-dev && \
+    apt-get clean && \
+    c_rehash && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \
+    sh /tmp/get-sentry.sh && \
+    rm -f /tmp/get-sentry.sh
+
+COPY package-builders/entrypoint.sh /entrypoint.sh
+COPY package-builders/cpack-deb.sh /build.sh
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/check-for-go-toolchain.sh /tmp/check-for-go-toolchain.sh
+RUN . /tmp/check-for-go-toolchain.sh && \
+    if ! ensure_go_toolchain; then \
+        echo "ERROR: ${GOLANG_FAILURE_REASON}" && exit 1 ; \
+    fi
+
+COPY scripts/install-rust.sh /install-rust.sh
+RUN /install-rust.sh
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/build.sh"]

--- a/package-builders/Dockerfile.ubuntu25.04.v2
+++ b/package-builders/Dockerfile.ubuntu25.04.v2
@@ -18,6 +18,8 @@ ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+                       dpkg-dev && \
+    apt-get install -y --no-install-recommends \
                        bison \
                        build-essential \
                        ca-certificates \
@@ -50,7 +52,6 @@ RUN apt-get update && \
                        libssl-dev \
                        libunwind-dev \
                        libuv1-dev \
-                       libxen-dev \
                        libzstd-dev \
                        make \
                        ninja-build \
@@ -61,8 +62,10 @@ RUN apt-get update && \
                        uuid-dev \
                        wget \
                        zlib1g-dev && \
-    apt-get clean && \
     c_rehash && \
+    dpkg-architecture --equal armhf || apt-get install -y --no-install-recommends \
+                       libxen-dev && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl --fail -sSL --connect-timeout 10 --retry 3 https://sentry.io/get-cli/ > /tmp/get-sentry.sh && \


### PR DESCRIPTION
- Add builders for CentOS Stream 10, Fedora 42, and Ubuntu 25.04
- Stop building EOL platforms.
- Stop building v1 builder images for DEB platforms (they aren’t used anymore).