### PR TITLE
Fix complaints from Docker build for base and builder images.

### DIFF
--- a/base/Dockerfile.v2
+++ b/base/Dockerfile.v2
@@ -6,7 +6,7 @@
 # Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
 # Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
-FROM debian:12 as builder
+FROM debian:12
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"

--- a/base/Dockerfile.v3
+++ b/base/Dockerfile.v3
@@ -6,7 +6,7 @@
 # Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
 # Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
-FROM debian:trixie as builder
+FROM debian:trixie
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"

--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -6,7 +6,7 @@
 # Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
 # Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
-FROM debian:12 as builder
+FROM debian:12
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"

--- a/builder/Dockerfile.v3
+++ b/builder/Dockerfile.v3
@@ -6,7 +6,7 @@
 # Author : Paul Emm. Katsoulakis <paul@netdata.rocks>
 # Author : Austin S. Hemmelgarn <austiN@netdata.cloud>
 
-FROM debian:trixie as builder
+FROM debian:trixie
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.source="https://github.com/netdata/helper-images"


### PR DESCRIPTION
The `as` clauses were not needed anyway, and Docker apparently now complains about case mismatches.