### PR TITLE
Add Clang to build environments.

### DIFF
--- a/builder/Dockerfile.v2
+++ b/builder/Dockerfile.v2
@@ -29,6 +29,7 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     bison \
                     build-essential \
                     ca-certificates \
+                    clang \
                     cmake \
                     curl \
                     dpkg-dev \

--- a/builder/Dockerfile.v3
+++ b/builder/Dockerfile.v3
@@ -29,6 +29,7 @@ RUN DISTRO_CODENAME="$(awk -F= '/VERSION_CODENAME/{print $2}' /etc/os-release)" 
                     bison \
                     build-essential \
                     ca-certificates \
+                    clang \
                     cmake \
                     curl \
                     dpkg-dev \

--- a/package-builders/Dockerfile.amazonlinux2.v1
+++ b/package-builders/Dockerfile.amazonlinux2.v1
@@ -16,6 +16,7 @@ RUN yum update -y && \
                    automake \
                    bison \
                    bison-devel \
+                   clang \
                    cmake \
                    cups-devel \
                    curl \

--- a/package-builders/Dockerfile.amazonlinux2.v2
+++ b/package-builders/Dockerfile.amazonlinux2.v2
@@ -12,6 +12,7 @@ ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 RUN yum update -y && \
     yum install -y bison \
                    bison-devel \
+                   clang \
                    cmake \
                    cups-devel \
                    curl \

--- a/package-builders/Dockerfile.amazonlinux2023.v1
+++ b/package-builders/Dockerfile.amazonlinux2023.v1
@@ -18,6 +18,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bison \
         bison-devel \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.amazonlinux2023.v2
+++ b/package-builders/Dockerfile.amazonlinux2023.v2
@@ -15,6 +15,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --allowerasing --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bison \
         bison-devel \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.centos-stream10.v1
+++ b/package-builders/Dockerfile.centos-stream10.v1
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.centos-stream9.v1
+++ b/package-builders/Dockerfile.centos-stream9.v1
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.centos-stream9.v2
+++ b/package-builders/Dockerfile.centos-stream9.v2
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.centos7.v1
+++ b/package-builders/Dockerfile.centos7.v1
@@ -22,6 +22,7 @@ RUN yum install -y epel-release && \
                    bash \
                    bison \
                    bison-devel \
+                   clang \
                    cmake \
                    cups-devel \
                    curl \

--- a/package-builders/Dockerfile.centos7.v2
+++ b/package-builders/Dockerfile.centos7.v2
@@ -18,6 +18,7 @@ RUN yum install -y epel-release && \
     yum install -y bash \
                    bison \
                    bison-devel \
+                   clang \
                    cmake \
                    cups-devel \
                    curl \

--- a/package-builders/Dockerfile.debian11.v2
+++ b/package-builders/Dockerfile.debian11.v2
@@ -21,6 +21,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        file \

--- a/package-builders/Dockerfile.debian12.v2
+++ b/package-builders/Dockerfile.debian12.v2
@@ -15,6 +15,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        file \

--- a/package-builders/Dockerfile.debian13.v2
+++ b/package-builders/Dockerfile.debian13.v2
@@ -15,6 +15,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        file \

--- a/package-builders/Dockerfile.fedora41.v1
+++ b/package-builders/Dockerfile.fedora41.v1
@@ -15,6 +15,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.fedora41.v2
+++ b/package-builders/Dockerfile.fedora41.v2
@@ -15,6 +15,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.fedora42.v1
+++ b/package-builders/Dockerfile.fedora42.v1
@@ -15,6 +15,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.fedora42.v2
+++ b/package-builders/Dockerfile.fedora42.v2
@@ -15,6 +15,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.opensuse15.6.v1
+++ b/package-builders/Dockerfile.opensuse15.6.v1
@@ -17,6 +17,7 @@ RUN zypper update -y && \
                       autogen \
                       automake \
                       bison \
+                      clang \
                       cmake \
                       cups \
                       cups-devel \

--- a/package-builders/Dockerfile.opensuse15.6.v2
+++ b/package-builders/Dockerfile.opensuse15.6.v2
@@ -13,6 +13,7 @@ ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 RUN zypper update -y && \
     zypper install -y --allow-downgrade \
                       bison \
+                      clang \
                       cmake \
                       cups \
                       cups-devel \

--- a/package-builders/Dockerfile.opensusetumbleweed.v1
+++ b/package-builders/Dockerfile.opensusetumbleweed.v1
@@ -16,6 +16,7 @@ RUN zypper update -y && \
                       autoconf-archive \
                       autogen \
                       automake \
+                      clang \
                       bison \
                       cmake \
                       cups \

--- a/package-builders/Dockerfile.opensusetumbleweed.v2
+++ b/package-builders/Dockerfile.opensusetumbleweed.v2
@@ -13,6 +13,7 @@ ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 RUN zypper update -y && \
     zypper install -y --allow-downgrade \
                       bison \
+                      clang \
                       cmake \
                       cups \
                       cups-devel \

--- a/package-builders/Dockerfile.oraclelinux10.v1
+++ b/package-builders/Dockerfile.oraclelinux10.v1
@@ -20,6 +20,7 @@ RUN dnf config-manager --set-enabled ol10_codeready_builder && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.oraclelinux10.v2
+++ b/package-builders/Dockerfile.oraclelinux10.v2
@@ -17,6 +17,7 @@ RUN dnf config-manager --set-enabled ol10_codeready_builder && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.oraclelinux8.v1
+++ b/package-builders/Dockerfile.oraclelinux8.v1
@@ -22,6 +22,7 @@ RUN dnf config-manager --set-enabled ol8_codeready_builder && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.oraclelinux8.v2
+++ b/package-builders/Dockerfile.oraclelinux8.v2
@@ -18,6 +18,7 @@ RUN dnf config-manager --set-enabled ol8_codeready_builder && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.oraclelinux9.v1
+++ b/package-builders/Dockerfile.oraclelinux9.v1
@@ -22,6 +22,7 @@ RUN dnf config-manager --set-enabled ol9_codeready_builder && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.oraclelinux9.v2
+++ b/package-builders/Dockerfile.oraclelinux9.v2
@@ -19,6 +19,7 @@ RUN dnf config-manager --set-enabled ol9_codeready_builder && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux10.v1
+++ b/package-builders/Dockerfile.rockylinux10.v1
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -17,6 +17,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --allowerasing --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux8.v1
+++ b/package-builders/Dockerfile.rockylinux8.v1
@@ -21,6 +21,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux8.v2
+++ b/package-builders/Dockerfile.rockylinux8.v2
@@ -17,6 +17,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux9.v1
+++ b/package-builders/Dockerfile.rockylinux9.v1
@@ -20,6 +20,7 @@ RUN dnf distro-sync -y --nodocs && \
         automake \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.rockylinux9.v2
+++ b/package-builders/Dockerfile.rockylinux9.v2
@@ -17,6 +17,7 @@ RUN dnf distro-sync -y --nodocs && \
     dnf install -y --allowerasing --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False \
         bash \
         bison \
+        clang \
         cmake \
         cups-devel \
         curl \

--- a/package-builders/Dockerfile.ubuntu20.04.v2
+++ b/package-builders/Dockerfile.ubuntu20.04.v2
@@ -21,6 +21,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        dpkg-dev \

--- a/package-builders/Dockerfile.ubuntu22.04.v2
+++ b/package-builders/Dockerfile.ubuntu22.04.v2
@@ -21,6 +21,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        file \

--- a/package-builders/Dockerfile.ubuntu24.04.v2
+++ b/package-builders/Dockerfile.ubuntu24.04.v2
@@ -21,6 +21,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        dpkg-dev \

--- a/package-builders/Dockerfile.ubuntu25.04.v2
+++ b/package-builders/Dockerfile.ubuntu25.04.v2
@@ -23,6 +23,7 @@ RUN apt-get update && \
                        bison \
                        build-essential \
                        ca-certificates \
+                       clang \
                        cmake \
                        curl \
                        dpkg-dev \

--- a/static-builder/Dockerfile.v1
+++ b/static-builder/Dockerfile.v1
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
     binutils \
     bison \
     cargo \
+    clang \
     cmake \
     coreutils \
     curl \


### PR DESCRIPTION
We’re looking at possibly switching from GCC to Clang to take advantage of faster builds (and possibly also ThinLTO) in CI, so we need it available in all of our build environments. This does not enable usage of it for any of our builds yet (that will be handled in the actual agent repository, not here).