### PR TITLE
Remove libmongoc-1.0 from RHEL 10 equivalent package builders.

### DIFF
--- a/package-builders/Dockerfile.centos-stream10.v1
+++ b/package-builders/Dockerfile.centos-stream10.v1
@@ -52,7 +52,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -52,7 +52,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.rockylinux10.v1
+++ b/package-builders/Dockerfile.rockylinux10.v1
@@ -52,7 +52,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -48,7 +48,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \


### PR DESCRIPTION
It’s been removed from CentOS Stream 10, and thus will be removed from RHEL 10 in the near future.