### PR TITLE
package-builders: prepare the RPM v2 images for the CPack packaging path

### DIFF
--- a/package-builders/Dockerfile.amazonlinux2.v2
+++ b/package-builders/Dockerfile.amazonlinux2.v2
@@ -54,7 +54,6 @@ RUN yum update -y && \
                    rpmdevtools \
                    snappy-devel \
                    systemd-devel \
-                   systemd-rpm-macros \
                    wget \
                    zlib-devel && \
     yum clean all && \

--- a/package-builders/Dockerfile.amazonlinux2.v2
+++ b/package-builders/Dockerfile.amazonlinux2.v2
@@ -50,6 +50,7 @@ RUN yum update -y && \
                    protobuf-c-devel \
                    protobuf-compiler \
                    protobuf-devel \
+                   rpm-build \
                    rpmdevtools \
                    snappy-devel \
                    systemd-devel \

--- a/package-builders/Dockerfile.amazonlinux2.v2
+++ b/package-builders/Dockerfile.amazonlinux2.v2
@@ -59,14 +59,15 @@ RUN yum update -y && \
     yum clean all && \
     c_rehash
 
-# Fetch a newer version of CMake, because the system-provided one is _ancient_.
+# Fetch a newer version of CMake, because the system-provided one is _ancient_
+# (and CPack RPM support needs CMake >= 4.1 for weak-dependency emission).
 # The hash is hard-coded here to mitigate the risk of supply-chain attacks.
 RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-$(uname -m).sh \
-         https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-$(uname -m).sh && \
+         https://github.com/Kitware/CMake/releases/download/v4.1.6/cmake-4.1.6-linux-$(uname -m).sh && \
     if [ "$(uname -m)" = "x86_64" ]; then \
-        echo '8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake-linux-x86_64.sh' | sha256sum -c - ; \
+        echo 'd471e4d0d89a708b0a4d32eff2005b10484e2b28be5644d896ee8a584f670db9  cmake-linux-x86_64.sh' | sha256sum -c - ; \
     elif [ "$(uname -m)" = "aarch64" ]; then \
-        echo 'a83e01ed1cdf44c2e33e0726513b9a35a8c09e3b5a126fd720b3c8a9d5552368  cmake-linux-aarch64.sh' | sha256sum -c - ; \
+        echo '7e457ec8678e797188674a639b4cc7df6c27666eae3fd2e431eb0b0c49c24e70  cmake-linux-aarch64.sh' | sha256sum -c - ; \
     else \
         echo "ARCH NOT SUPPORTED BY CMAKE" ; \
         exit 1 ; \

--- a/package-builders/Dockerfile.amazonlinux2.v2
+++ b/package-builders/Dockerfile.amazonlinux2.v2
@@ -60,22 +60,10 @@ RUN yum update -y && \
     yum clean all && \
     c_rehash
 
-# Fetch a newer version of CMake, because the system-provided one is _ancient_
-# (and CPack RPM support needs CMake >= 4.1 for weak-dependency emission).
-# The hash is hard-coded here to mitigate the risk of supply-chain attacks.
-RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-$(uname -m).sh \
-         https://github.com/Kitware/CMake/releases/download/v4.1.6/cmake-4.1.6-linux-$(uname -m).sh && \
-    if [ "$(uname -m)" = "x86_64" ]; then \
-        echo 'd471e4d0d89a708b0a4d32eff2005b10484e2b28be5644d896ee8a584f670db9  cmake-linux-x86_64.sh' | sha256sum -c - ; \
-    elif [ "$(uname -m)" = "aarch64" ]; then \
-        echo '7e457ec8678e797188674a639b4cc7df6c27666eae3fd2e431eb0b0c49c24e70  cmake-linux-aarch64.sh' | sha256sum -c - ; \
-    else \
-        echo "ARCH NOT SUPPORTED BY CMAKE" ; \
-        exit 1 ; \
-    fi && \
-    chmod +x ./cmake-linux-$(uname -m).sh && \
-    mkdir -p /cmake && \
-    ./cmake-linux-$(uname -m).sh --skip-license --prefix=/cmake
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh

--- a/package-builders/Dockerfile.amazonlinux2023.v2
+++ b/package-builders/Dockerfile.amazonlinux2023.v2
@@ -60,6 +60,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -73,18 +78,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.amazonlinux2023.v2
+++ b/package-builders/Dockerfile.amazonlinux2023.v2
@@ -50,6 +50,7 @@ RUN dnf distro-sync -y --nodocs && \
         protobuf-c-devel \
         protobuf-compiler \
         protobuf-devel \
+        rpm-build \
         rpmdevtools \
         snappy-devel \
         systemd-devel \

--- a/package-builders/Dockerfile.amazonlinux2023.v2
+++ b/package-builders/Dockerfile.amazonlinux2023.v2
@@ -73,5 +73,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -10,6 +10,9 @@ ENV VERSION=$VERSION
 # Dummy Sentry DSN
 ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 
+# Unlike the older EL images there is no libmongoc here: mongo-c-driver is
+# not available in EPEL 10, and netdata disables the MongoDB exporter on
+# EL >= 10 for the same reason.
 RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled crb && \

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -83,5 +83,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -52,7 +52,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.centos-stream10.v2
+++ b/package-builders/Dockerfile.centos-stream10.v2
@@ -69,6 +69,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -82,18 +87,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos-stream9.v2
+++ b/package-builders/Dockerfile.centos-stream9.v2
@@ -84,5 +84,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos-stream9.v2
+++ b/package-builders/Dockerfile.centos-stream9.v2
@@ -70,6 +70,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -83,18 +88,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.centos7.v2
+++ b/package-builders/Dockerfile.centos7.v2
@@ -60,7 +60,6 @@ RUN yum install -y epel-release && \
                    rpmdevtools \
                    snappy-devel \
                    systemd-devel \
-                   systemd-rpm-macros \
                    wget \
                    zlib-devel && \
     yum clean all && \

--- a/package-builders/Dockerfile.centos7.v2
+++ b/package-builders/Dockerfile.centos7.v2
@@ -66,14 +66,15 @@ RUN yum install -y epel-release && \
     yum clean all && \
     c_rehash
 
-# Fetch a newer version of CMake, because the system-provided one is _ancient_.
+# Fetch a newer version of CMake, because the system-provided one is _ancient_
+# (and CPack RPM support needs CMake >= 4.1 for weak-dependency emission).
 # The hash is hard-coded here to mitigate the risk of supply-chain attacks.
 RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-$(uname -m).sh \
-         https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-$(uname -m).sh && \
+         https://github.com/Kitware/CMake/releases/download/v4.1.6/cmake-4.1.6-linux-$(uname -m).sh && \
     if [ "$(uname -m)" = "x86_64" ]; then \
-        echo '8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake-linux-x86_64.sh' | sha256sum -c - ; \
+        echo 'd471e4d0d89a708b0a4d32eff2005b10484e2b28be5644d896ee8a584f670db9  cmake-linux-x86_64.sh' | sha256sum -c - ; \
     elif [ "$(uname -m)" = "aarch64" ]; then \
-        echo 'a83e01ed1cdf44c2e33e0726513b9a35a8c09e3b5a126fd720b3c8a9d5552368  cmake-linux-aarch64.sh' | sha256sum -c - ; \
+        echo '7e457ec8678e797188674a639b4cc7df6c27666eae3fd2e431eb0b0c49c24e70  cmake-linux-aarch64.sh' | sha256sum -c - ; \
     else \
         echo "ARCH NOT SUPPORTED BY CMAKE" ; \
         exit 1 ; \

--- a/package-builders/Dockerfile.centos7.v2
+++ b/package-builders/Dockerfile.centos7.v2
@@ -66,22 +66,10 @@ RUN yum install -y epel-release && \
     yum clean all && \
     c_rehash
 
-# Fetch a newer version of CMake, because the system-provided one is _ancient_
-# (and CPack RPM support needs CMake >= 4.1 for weak-dependency emission).
-# The hash is hard-coded here to mitigate the risk of supply-chain attacks.
-RUN curl --fail -sSL --connect-timeout 20 --retry 3 --output cmake-linux-$(uname -m).sh \
-         https://github.com/Kitware/CMake/releases/download/v4.1.6/cmake-4.1.6-linux-$(uname -m).sh && \
-    if [ "$(uname -m)" = "x86_64" ]; then \
-        echo 'd471e4d0d89a708b0a4d32eff2005b10484e2b28be5644d896ee8a584f670db9  cmake-linux-x86_64.sh' | sha256sum -c - ; \
-    elif [ "$(uname -m)" = "aarch64" ]; then \
-        echo '7e457ec8678e797188674a639b4cc7df6c27666eae3fd2e431eb0b0c49c24e70  cmake-linux-aarch64.sh' | sha256sum -c - ; \
-    else \
-        echo "ARCH NOT SUPPORTED BY CMAKE" ; \
-        exit 1 ; \
-    fi && \
-    chmod +x ./cmake-linux-$(uname -m).sh && \
-    mkdir -p /cmake && \
-    ./cmake-linux-$(uname -m).sh --skip-license --prefix=/cmake
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
 
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh

--- a/package-builders/Dockerfile.fedora41.v2
+++ b/package-builders/Dockerfile.fedora41.v2
@@ -61,6 +61,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -74,18 +79,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora41.v2
+++ b/package-builders/Dockerfile.fedora41.v2
@@ -75,5 +75,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora42.v2
+++ b/package-builders/Dockerfile.fedora42.v2
@@ -61,6 +61,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -74,18 +79,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora42.v2
+++ b/package-builders/Dockerfile.fedora42.v2
@@ -75,5 +75,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora43.v2
+++ b/package-builders/Dockerfile.fedora43.v2
@@ -61,6 +61,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -74,18 +79,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora43.v2
+++ b/package-builders/Dockerfile.fedora43.v2
@@ -75,5 +75,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora44.v2
+++ b/package-builders/Dockerfile.fedora44.v2
@@ -61,6 +61,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -74,18 +79,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.fedora44.v2
+++ b/package-builders/Dockerfile.fedora44.v2
@@ -75,5 +75,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensuse15.6.v2
+++ b/package-builders/Dockerfile.opensuse15.6.v2
@@ -62,6 +62,11 @@ RUN zypper update -y && \
     rm -rf /var/cache/zypp/*/* && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -75,18 +80,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensuse15.6.v2
+++ b/package-builders/Dockerfile.opensuse15.6.v2
@@ -75,5 +75,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensuse15.6.v2
+++ b/package-builders/Dockerfile.opensuse15.6.v2
@@ -49,6 +49,7 @@ RUN zypper update -y && \
                       patch \
                       pkg-config \
                       protobuf-devel \
+                      rpm-build \
                       rpmdevtools \
                       snappy-devel \
                       systemd-devel \

--- a/package-builders/Dockerfile.opensuse16.0.v2
+++ b/package-builders/Dockerfile.opensuse16.0.v2
@@ -59,6 +59,11 @@ RUN zypper update -y && \
     rm -rf /var/cache/zypp/*/* && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -72,18 +77,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensuse16.0.v2
+++ b/package-builders/Dockerfile.opensuse16.0.v2
@@ -47,6 +47,7 @@ RUN zypper update -y && \
                       pkgconf \
                       protobuf-devel \
                       protobuf-c-devel \
+                      rpm-build \
                       rpmdevtools \
                       snappy-devel \
                       systemd-devel \

--- a/package-builders/Dockerfile.opensuse16.0.v2
+++ b/package-builders/Dockerfile.opensuse16.0.v2
@@ -72,5 +72,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensusetumbleweed.v2
+++ b/package-builders/Dockerfile.opensusetumbleweed.v2
@@ -74,5 +74,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.opensusetumbleweed.v2
+++ b/package-builders/Dockerfile.opensusetumbleweed.v2
@@ -48,6 +48,7 @@ RUN zypper update -y && \
                       pkg-config \
                       protobuf-c \
                       protobuf-devel \
+                      rpm-build \
                       rpmdevtools \
                       snappy-devel \
                       systemd-devel \

--- a/package-builders/Dockerfile.opensusetumbleweed.v2
+++ b/package-builders/Dockerfile.opensusetumbleweed.v2
@@ -61,6 +61,11 @@ RUN zypper update -y && \
     rm -rf /var/cache/zypp/*/* && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -74,18 +79,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux10.v2
+++ b/package-builders/Dockerfile.oraclelinux10.v2
@@ -10,6 +10,9 @@ ENV VERSION=$VERSION
 # Dummy Sentry DSN
 ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 
+# Unlike the older EL images there is no libmongoc here: mongo-c-driver is
+# not available in EPEL 10, and netdata disables the MongoDB exporter on
+# EL >= 10 for the same reason.
 RUN dnf config-manager --set-enabled ol10_codeready_builder && \
     dnf install -y --nodocs --setopt=install_weak_deps=False --setopt=diskspacecheck=False oracle-epel-release-el10 && \
     dnf distro-sync -y --nodocs && \

--- a/package-builders/Dockerfile.oraclelinux10.v2
+++ b/package-builders/Dockerfile.oraclelinux10.v2
@@ -48,7 +48,6 @@ RUN dnf config-manager --set-enabled ol10_codeready_builder && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.oraclelinux10.v2
+++ b/package-builders/Dockerfile.oraclelinux10.v2
@@ -64,6 +64,11 @@ RUN dnf config-manager --set-enabled ol10_codeready_builder && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -77,18 +82,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux10.v2
+++ b/package-builders/Dockerfile.oraclelinux10.v2
@@ -78,5 +78,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux8.v2
+++ b/package-builders/Dockerfile.oraclelinux8.v2
@@ -81,5 +81,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux8.v2
+++ b/package-builders/Dockerfile.oraclelinux8.v2
@@ -67,6 +67,11 @@ RUN dnf config-manager --set-enabled ol8_codeready_builder && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -80,18 +85,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux9.v2
+++ b/package-builders/Dockerfile.oraclelinux9.v2
@@ -67,6 +67,11 @@ RUN dnf config-manager --set-enabled ol9_codeready_builder && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -80,18 +85,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.oraclelinux9.v2
+++ b/package-builders/Dockerfile.oraclelinux9.v2
@@ -81,5 +81,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -10,6 +10,9 @@ ENV VERSION=$VERSION
 # Dummy Sentry DSN
 ENV SENTRY_DSN="https://1ea0662a@o01e.ingest.sentry.io/dummy"
 
+# Unlike the older EL images there is no libmongoc here: mongo-c-driver is
+# not available in EPEL 10, and netdata disables the MongoDB exporter on
+# EL >= 10 for the same reason.
 RUN dnf distro-sync -y --nodocs && \
     dnf install -y --nodocs 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled crb && \

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -48,7 +48,6 @@ RUN dnf distro-sync -y --nodocs && \
         patch \
         pcre2-devel \
         pkgconfig \
-        'pkgconfig(libmongoc-1.0)' \
         'pkgconfig(odbc)' \
         procps \
         protobuf-c-devel \

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -64,6 +64,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -77,18 +82,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux10.v2
+++ b/package-builders/Dockerfile.rockylinux10.v2
@@ -78,5 +78,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux8.v2
+++ b/package-builders/Dockerfile.rockylinux8.v2
@@ -65,6 +65,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -78,18 +83,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux8.v2
+++ b/package-builders/Dockerfile.rockylinux8.v2
@@ -79,5 +79,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux9.v2
+++ b/package-builders/Dockerfile.rockylinux9.v2
@@ -65,6 +65,11 @@ RUN dnf distro-sync -y --nodocs && \
     rm -rf /var/cache/dnf && \
     c_rehash
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+COPY scripts/install-cmake.sh /install-cmake.sh
+RUN /install-cmake.sh
+
 COPY package-builders/entrypoint.sh /entrypoint.sh
 COPY package-builders/cpack-rpm.sh /build.sh
 
@@ -78,18 +83,6 @@ RUN . /tmp/check-for-go-toolchain.sh && \
 COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
-
-# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
-# entrypoint prefers /cmake/bin when present.
-ARG CMAKE_VERSION=4.1.6
-RUN case "$(uname -m)" in \
-        x86_64) cmake_arch=x86_64 ;; \
-        aarch64) cmake_arch=aarch64 ;; \
-        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
-      | tar -xz -C /opt && \
-    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/package-builders/Dockerfile.rockylinux9.v2
+++ b/package-builders/Dockerfile.rockylinux9.v2
@@ -79,5 +79,17 @@ COPY scripts/install-rust.sh /install-rust.sh
 RUN /install-rust.sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# CPack RPM support needs CMake >= 4.1 (weak-dependency emission); the
+# entrypoint prefers /cmake/bin when present.
+ARG CMAKE_VERSION=4.1.6
+RUN case "$(uname -m)" in \
+        x86_64) cmake_arch=x86_64 ;; \
+        aarch64) cmake_arch=aarch64 ;; \
+        *) echo "No CMake binary release for $(uname -m)" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz" \
+      | tar -xz -C /opt && \
+    ln -s "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/build.sh"]

--- a/scripts/install-cmake.sh
+++ b/scripts/install-cmake.sh
@@ -25,11 +25,17 @@ esac
 
 tarball="cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz"
 
-curl --fail -sSL --connect-timeout 20 --retry 3 --output "/tmp/${tarball}" \
+curl --fail -sSL --connect-timeout 20 --retry 3 --max-time 600 --output "/tmp/${tarball}" \
      "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${tarball}"
 echo "${cmake_sha256}  /tmp/${tarball}" | sha256sum -c -
 tar -xzf "/tmp/${tarball}" -C /opt
 rm -f "/tmp/${tarball}"
+
+# Fail the image build if a future release changes the tarball layout; a
+# dangling /cmake symlink would otherwise make the entrypoint silently fall
+# back to the distro CMake.
+test -x "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}/bin/cmake"
+
 # -T so a pre-existing /cmake directory fails the build instead of silently
 # nesting the symlink inside it.
 ln -sT "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake

--- a/scripts/install-cmake.sh
+++ b/scripts/install-cmake.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Install the pinned CMake release used by the RPM v2 package builders.
+# CPack only emits RPM weak dependencies (Recommends/Suggests) from CMake 4.1
+# on, and the container entrypoint prefers /cmake/bin when present.
+# The hashes are hard-coded here to mitigate the risk of supply-chain attacks;
+# they come from the cmake-${CMAKE_VERSION}-SHA-256.txt upstream release asset.
+set -eu
+
+CMAKE_VERSION=4.1.6
+
+case "$(uname -m)" in
+    x86_64)
+        cmake_arch=x86_64
+        cmake_sha256=d5c2e72820e01f1c3a07092d0a29e209263a7d22f55b4ad7f414ee870ae6b8e0
+        ;;
+    aarch64)
+        cmake_arch=aarch64
+        cmake_sha256=8b3e3af8e4b4e95224a4490f4772adb7a512be34c8380fe76e7be003e0fd4394
+        ;;
+    *)
+        echo "No CMake binary release for $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+tarball="cmake-${CMAKE_VERSION}-linux-${cmake_arch}.tar.gz"
+
+curl --fail -sSL --connect-timeout 20 --retry 3 --output "/tmp/${tarball}" \
+     "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${tarball}"
+echo "${cmake_sha256}  /tmp/${tarball}" | sha256sum -c -
+tar -xzf "/tmp/${tarball}" -C /opt
+rm -f "/tmp/${tarball}"
+# -T so a pre-existing /cmake directory fails the build instead of silently
+# nesting the symlink inside it.
+ln -sT "/opt/cmake-${CMAKE_VERSION}-linux-${cmake_arch}" /cmake


### PR DESCRIPTION
## Summary

Prepares all eighteen RPM `v2` package-builder images for building Netdata RPMs through `cpack -G RPM` (the `cpack-rpm.sh` entrypoint these images already ship). A companion PR on the netdata repository adds the CPack RPM configuration itself; nothing in production changes until `builder_rev` is flipped in netdata's `.github/data/distros.yml`.

## Changes

- **CMake 4.1.6 in every RPM `v2` image**, installed under `/cmake` (the path `entrypoint.sh` already prefers). CPack emits `Recommends:` tags only from CMake 4.1 on and silently ignores the variables on older versions; since dnf installs recommends by default, losing them would be a real packaging regression.
- **One shared, verified installer**: `scripts/install-cmake.sh` (modeled on `install-rust.sh`) pins the upstream SHA-256 per architecture and fails the image build on any checksum mismatch, stalled download, or unexpected tarball layout. The centos7 and amazonlinux2 images, which carried their own pinned CMake 3.27.6 installer, moved onto the same script.
- **`rpm-build` added** to the openSUSE and Amazon Linux `v2` images, which listed only `rpmdevtools` and could never have run `cpack -G RPM`.
- **libmongoc removed from the EL10 `v2` images**: `pkgconfig(libmongoc-1.0)` does not exist in EPEL 10, so these images were unbuildable; netdata disables the MongoDB exporter on EL 10 for the same reason. In-file comments document this. (The `v1` EL10 Dockerfiles carry the same defect and remain unbuildable — left untouched here as they are the production path.)
- **`systemd-rpm-macros` dropped from the EL7-era `v2` images**: on EL7 that name resolves to EPEL's `epel-rpm-macros-systemd`, whose sysusers file-attribute generator invents `user()`/`group()` provides that spec-built packages do not have. Base systemd ships the `%systemd_*` macros. This applies only to the EL7 tier — on EL8+/Fedora/openSUSE `systemd-rpm-macros` is the real systemd subpackage, present in the `v1` environments too.

## Validation

- Every edited image was rebuilt locally and verified to report `/cmake/bin/cmake --version` = 4.1.6 with `rpmbuild` present; the Kitware binary runs fine on centos7's glibc 2.17.
- The images were exercised end-to-end by the netdata-side parity work: RPMs built through these images via CPack were compared field-by-field (package set, dependencies including weak ones, per-file modes/owners/caps, scriptlets, changelog) against spec-built reference RPMs from the `v1` images, reaching full parity on an eight-distro sample covering every tier (CentOS Stream 9, Rocky 8, Fedora 42/44, openSUSE 15.6, Amazon Linux 2023, CentOS 7, Amazon Linux 2), plus a direct inspection on CentOS Stream 10 where no `v1` reference build is possible.